### PR TITLE
Group load

### DIFF
--- a/docs/notebooks/pynapple-io-notebook.ipynb
+++ b/docs/notebooks/pynapple-io-notebook.ipynb
@@ -3,7 +3,11 @@
   {
    "cell_type": "markdown",
    "id": "b582a340",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# IO Tutorial\n",
     "\n",
@@ -21,7 +25,11 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "25fcec41",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -33,7 +41,11 @@
   {
    "cell_type": "markdown",
    "id": "0f110346",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "In this [example dataset](https://www.dropbox.com/s/1kc0ulz7yudd9ru/A2929-200711.tar.gz?dl=1), the data contains a sample recording from the anterodorsal nucleus of the thalamus and the hippocampus, with both a sleep and a wake phase. It contains both head-direction cells (i.e. cells that fire for a particular direction of the head in the horizontal plane) and place cells (i.e. cells that fire for a particular position in the environment).\n",
     "\n",
@@ -51,7 +63,11 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "78ade0f2",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "data_directory = '../../your/path/to/A2929-200711'\n",
@@ -62,7 +78,11 @@
   {
    "cell_type": "markdown",
    "id": "b571f99d",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "<img src=\"Screenshot1_baseloader.png\" width=700 height=700 />\n",
     "\n",
@@ -107,7 +127,11 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "cc6e0c52",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "data = nap.load_session(data_directory, 'neurosuite')"
@@ -116,7 +140,11 @@
   {
    "cell_type": "markdown",
    "id": "fdb068f8",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "In this case, the data that can be used for analysis are *spikes*, *position* and *epochs*."
    ]
@@ -125,7 +153,11 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "9bdbc807",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -185,7 +217,11 @@
   {
    "cell_type": "markdown",
    "id": "85a7d643",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "--- \n",
     "\n",
@@ -198,7 +234,11 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "eb9942ad",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",

--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -100,7 +100,7 @@ class Tsd(pd.Series):
 
         t = TimeUnits.format_timestamps(t, time_units)
 
-        if len(t):
+        if len(t) > 0:
             if time_support is not None:
                 bins = time_support.values.ravel()
                 # Because yes there is no funtion with both bounds closed as an option
@@ -127,7 +127,10 @@ class Tsd(pd.Series):
             super().__init__(index=t, data=d, dtype=np.float64)
 
         self.time_support = time_support
-        self.rate = len(t)/self.time_support.tot_length('s')
+        if self.time_support.tot_length('s') > 0:
+            self.rate = len(t) / self.time_support.tot_length('s')
+        else:
+            self.rate = np.nan
         self.index.name = "Time (s)"
         self._metadata.append("nap_class")
         self.nap_class = self.__class__.__name__

--- a/pynapple/core/ts_group.py
+++ b/pynapple/core/ts_group.py
@@ -107,7 +107,7 @@ class TsGroup(UserDict):
                 raise RuntimeError("Intersection of time supports is empty. Consider passing a time support as argument.")
             self.time_support = time_support                
             data = {k:data[k].restrict(self.time_support) for k in index}
-
+        #print(data)
         UserDict.__init__(self, data)
         
         # Making the TsGroup non mutable


### PR DESCRIPTION
Here it is! 
In this PR, I addressed:
 - #96 by making the column from which infos are loaded either "group" or "KSLabel" [here](https://github.com/iurillilab/pynapple/blob/c46d80b00abbc38a3782aa4a6069b8454a157817/pynapple/io/phy.py#L177)
 - In doing so, I refactored a bit the loading function, it had some brittle parts. I made `cluster_info`/`cluster_group` only `cluster_info`, and not making it an attribute as it is set and used only in the method to load from Phy folder.
 - There's also a minor fix in the rates calculation, for some reason with my very ugly data I have neurons with no spikes and was getting time supports of 0 duration; now frequency is set to np.nan in those cases. I think in general is a good fallback but happy to remove it if it is too specific for my edge case
 - I implemented what I suggested in #97: now spikes are all loaded, regardless of their classification, in the self._all_spikes attribute; and then selected (with caching, as the `TsGroup` indexing seems slow, 1-2s) when querying the self.spikes property, depending on what is specified in the `valid_group_labels` argument (by default `["good"]`). Labels are stored as a "label" unit attribute in the nab file. Back compatibility is ensued by the fact that if no label is found in the file, the filtering is just always returning all spikes.

Locally, tests are running. I don't find specifications for linting (are you considering implementing it? I'd recommend it!) so I don't know what to adhere to formatting-wise, feel free to let me know in case.
I will make sure I clean up prints and notebooks changes.
Let me know! And thank you for the package!