### PR TITLE
NWB fixes

### DIFF
--- a/pynapple/io/interface_nwb.py
+++ b/pynapple/io/interface_nwb.py
@@ -7,7 +7,7 @@
 """
 Pynapple class to interface with NWB files.
 Data are always lazy-loaded.
-Object behaves like dictionnary.
+Object behaves like dictionary.
 """
 
 import errno
@@ -35,7 +35,7 @@ def _extract_compatible_data_from_nwbfile(nwbfile):
     Returns
     -------
     dict
-        Dictionnary containing all the object found and their type in pynapple.
+        Dictionary containing all the object found and their type in pynapple.
     """
     data = {}
 
@@ -316,7 +316,7 @@ class NWBFile(UserDict):
                 raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), file)
         elif isinstance(file, pynwb.file.NWBFile):
             self.nwb = file
-            self.name = self.nwb.subject.subject_id
+            self.name = self.nwb.session_id
 
         else:
             raise RuntimeError(
@@ -366,7 +366,7 @@ class NWBFile(UserDict):
         Raises
         ------
         KeyError
-            If key is not in the dictionnary
+            If key is not in the dictionary
         """
         if key.__hash__:
             if self.__contains__(key):

--- a/setup.py
+++ b/setup.py
@@ -11,26 +11,25 @@ with open('README.md') as readme_file:
 #     history = history_file.read()
 
 requirements = [
-        'pandas>=1.0.3,<2.0.0',
-        'numba>=0.46.0',
-        'numpy>=1.17.4',
-        'scipy>=1.3.2',
-        'pynwb>=2.0.0',
-        'tabulate',
-        'h5py',
-        'tifffile',
-        'zarr',
-        'rich'
-        ]
+    'pandas>=1.0.3,<2.0.0',
+    'numba>=0.46.0',
+    'numpy>=1.17.4',
+    'scipy>=1.3.2',
+    'pynwb>=2.0.0',
+    'tabulate',
+    'h5py',
+    'tifffile',
+    'zarr',
+    'rich'
+]
 
 test_requirements = [
     'pytest',
     'isort',
     'pip-tools',
-    'pytest',
     'flake8',
     'coverage'
-    ]
+]
 
 setup(
     author="Guillaume Viejo",

--- a/tests/test_nwb.py
+++ b/tests/test_nwb.py
@@ -104,12 +104,14 @@ def test_wrong_key():
     with pytest.raises(KeyError):
         nwb["a"]
 
+
 def test_failed_to_build():
-    nwbfile = mock_NWBFile()
+    from pynwb.file import Subject
+    nwbfile = mock_NWBFile(subject=Subject(subject_id="mouse1"))
     nwb = nap.NWBFile(nwbfile)    
     for oid, obj in nwbfile.objects.items():                                                                                                                                   
         nwb.key_to_id[obj.name] = oid 
-        nwb[obj.name] = {"id":oid, "type":"Tsd"}
+        nwb[obj.name] = {"id": oid, "type": "Tsd"}
 
     with pytest.warns(UserWarning) as record:
         nwb["subject"]
@@ -530,12 +532,13 @@ def test_add_Units():
     np.testing.assert_array_equal(data._metadata["quality"].values, np.array(["good"]*n_units))
     np.testing.assert_array_equal(data._metadata["alpha"].values, alpha)
 
+
 def test_add_Timestamps():
     from pynwb.misc import AnnotationSeries
     from pynwb.core import DynamicTable, VectorData
 
     nwbfile = mock_NWBFile()
-    nwbfile.add_acquisition(AnnotationSeries("test_ts", data = np.array(["test"]*100), timestamps=np.arange(100)))
+    nwbfile.add_acquisition(AnnotationSeries("test_ts", data=np.array(["test"]*100), timestamps=np.arange(100)))
     nwb = nap.NWBFile(nwbfile)
     assert len(nwb) == 1
     assert "test_ts" in nwb.keys()


### PR DESCRIPTION
- Improve setup.py with uniform indenting and remove redundant packages
- The name field uses nwb.session_id, since nwb.subject is not required to always exist
- Ensure a subject is created when needed in the test
- fixing a few typos