### PR TITLE
Ts group getitem

### DIFF
--- a/pynapple/core/ts_group.py
+++ b/pynapple/core/ts_group.py
@@ -224,7 +224,7 @@ class TsGroup(UserDict):
             elif key in self._metadata.columns:
                 return self.get_info(key)
             else:
-                raise KeyError("Can't find key {} in group index.".format(key))
+                raise KeyError(f"Can't find key {key} in group index.")
 
         # array boolean are transformed into indices
         # note that raw boolean are hashable, and won't be
@@ -241,7 +241,7 @@ class TsGroup(UserDict):
         return self._ts_group_from_keys(key)
 
     def _ts_group_from_keys(self, keys):
-        metadata = self._metadata.loc[keys, self._metadata.columns.drop("rate")]
+        metadata = self._metadata.loc[np.sort(keys), self._metadata.columns.drop("rate")]
         return TsGroup(
                 {k: self[k] for k in keys}, time_support=self.time_support, **metadata
             )

--- a/pynapple/core/ts_group.py
+++ b/pynapple/core/ts_group.py
@@ -232,7 +232,7 @@ class TsGroup(UserDict):
         elif np.asarray(key).dtype == bool:
             key = np.asarray(key)
             if key.ndim != 1:
-                raise KeyError("Only 1-dimensional boolean indices are allowed!")
+                raise IndexError("Only 1-dimensional boolean indices are allowed!")
             if len(key) != self.__len__():
                 raise IndexError("Boolean index length must be equal to the number of Ts in the group! "
                                  f"The number of Ts is {self.__len__()}, but the bolean array"

--- a/pynapple/io/interface_npz.py
+++ b/pynapple/io/interface_npz.py
@@ -127,6 +127,7 @@ class NPZFile(object):
                     "index",
                     "d",
                     "rate",
+                    "keys"
                 }:
                     tmp = self.file[k]
                     if len(tmp) == len(tsgroup):

--- a/tests/test_npz_file.py
+++ b/tests/test_npz_file.py
@@ -56,12 +56,63 @@ def test_init(path):
     assert file.type == "Tsd"
 
 @pytest.mark.parametrize("path", [path])
-def test_load(path):
-    for k in data.keys():
-        file_path = os.path.join(path, k+".npz")
-        file = nap.NPZFile(file_path)
-        tmp = file.load()
-        assert type(tmp) == type(data[k])       
+@pytest.mark.parametrize("k", ['tsd', 'ts', 'tsdframe', 'tsgroup', 'iset'])
+def test_load(path, k):
+    file_path = os.path.join(path, k+".npz")
+    file = nap.NPZFile(file_path)
+    tmp = file.load()
+    assert type(tmp) == type(data[k])
+
+@pytest.mark.parametrize("path", [path])
+@pytest.mark.parametrize("k", ['tsgroup'])
+def test_load_tsgroup(path, k):
+    file_path = os.path.join(path, k+".npz")
+    file = nap.NPZFile(file_path)
+    tmp = file.load()
+    assert type(tmp) == type(data[k])
+    assert tmp.keys() == data[k].keys()
+    assert np.all(tmp._metadata == data[k]._metadata)
+    assert np.all(tmp[neu] == data[k][neu] for neu in tmp.keys())
+    assert np.all(tmp.time_support == data[k].time_support)
+
+
+@pytest.mark.parametrize("path", [path])
+@pytest.mark.parametrize("k", ['tsd'])
+def test_load_tsd(path, k):
+    file_path = os.path.join(path, k+".npz")
+    file = nap.NPZFile(file_path)
+    tmp = file.load()
+    assert type(tmp) == type(data[k])
+    assert np.all(tmp.d == data[k].d)
+    assert np.all(tmp.t == data[k].t)
+    assert np.all(tmp.time_support == data[k].time_support)
+
+
+@pytest.mark.parametrize("path", [path])
+@pytest.mark.parametrize("k", ['ts'])
+def test_load_ts(path, k):
+    file_path = os.path.join(path, k+".npz")
+    file = nap.NPZFile(file_path)
+    tmp = file.load()
+    assert type(tmp) == type(data[k])
+    assert np.all(tmp.t == data[k].t)
+    assert np.all(tmp.time_support == data[k].time_support)
+
+
+
+@pytest.mark.parametrize("path", [path])
+@pytest.mark.parametrize("k", ['tsdframe'])
+def test_load_tsdframe(path, k):
+    file_path = os.path.join(path, k+".npz")
+    file = nap.NPZFile(file_path)
+    tmp = file.load()
+    assert type(tmp) == type(data[k])
+    assert np.all(tmp.t == data[k].t)
+    assert np.all(tmp.time_support == data[k].time_support)
+    assert np.all(tmp.columns == data[k].columns)
+    assert np.all(tmp.d == data[k].d)
+
+
 
 @pytest.mark.parametrize("path", [path])
 def test_load_non_npz(path):

--- a/tests/test_ts_group.py
+++ b/tests/test_ts_group.py
@@ -177,16 +177,6 @@ class TestTsGroup1:
             tsgroup.set_info(ar=ar_info)
         assert str(e_info.value) == "Array is not the same length."
 
-    def test_non_mutability(self, group):
-        tsgroup = nap.TsGroup(group)
-        with pytest.raises(Exception) as e_info:
-            tsgroup[4] = nap.Ts(t=np.arange(4))
-        assert str(e_info.value) == "TsGroup object is not mutable."
-        tsgroup = nap.TsGroup(group)
-        with pytest.raises(Exception) as e_info:
-            tsgroup[3] = nap.Ts(t=np.arange(4))
-        assert str(e_info.value) == "TsGroup object is not mutable."
-
     def test_keys(self, group):
         tsgroup = nap.TsGroup(group)
         assert tsgroup.keys() == [0, 1, 2]

--- a/tests/test_ts_group.py
+++ b/tests/test_ts_group.py
@@ -12,6 +12,7 @@ import pandas as pd
 import pytest
 from collections import UserDict
 import warnings
+from contextlib import nullcontext as does_not_raise
 
 
 @pytest.mark.parametrize(
@@ -562,4 +563,23 @@ class Test_Ts_Group_1:
         os.remove("tsgroup2.npz")
         os.remove("tsgroup3.npz")
 
+    @pytest.mark.parametrize(
+        "keys, expectation",
+        [
+            (1, does_not_raise()),
+            ([1, 2], does_not_raise()),
+            ([1, 2], does_not_raise()),
+            (np.array([1, 2]), does_not_raise()),
+            (np.array([False, True, True]), does_not_raise()),
+            ([False, True, True], does_not_raise()),
+            (True, does_not_raise()),
+            (4, pytest.raises(KeyError, match="Can't find key")),
+            ([3, 4], pytest.raises(KeyError, match= r"None of \[Index\(\[3, 4\]")),
+            ([2, 3], pytest.raises(KeyError, match=r"\[3\] not in index"))
+        ]
+    )
+    def test_indexing_type(self, group, keys, expectation):
+        ts_group = nap.TsGroup(group)
+        with expectation:
+            out = ts_group[keys]
 

--- a/tests/test_ts_group.py
+++ b/tests/test_ts_group.py
@@ -744,3 +744,15 @@ class TestTsGroup1:
     def test_getitem_attribute_error(self, ts_group):
         with pytest.raises(AttributeError, match="'TsGroup' object has no attribute"):
             _ = ts_group.nonexistent_metadata
+
+    @pytest.mark.parametrize(
+        "bool_idx, expectation",
+        [
+            (np.ones((3,), dtype=bool), pytest.raises(IndexError, match="Boolean index length must be equal")),
+            (np.ones((2, 1), dtype=bool), pytest.raises(IndexError, match="Only 1-dimensional boolean indices")),
+            (np.array(True), pytest.raises(IndexError, match="Only 1-dimensional boolean indices"))
+        ]
+    )
+    def test_getitem_boolean_fail(self, ts_group, bool_idx, expectation):
+        with expectation:
+            out = ts_group[bool_idx]

--- a/tests/test_ts_group.py
+++ b/tests/test_ts_group.py
@@ -155,7 +155,6 @@ class TestTsGroup1:
             tsgroup.set_info(ar_info)
         assert str(e_info.value) == "Argument should be passed as keyword argument."
 
-
     def test_add_metainfo_test_runtime_errors(self, group):
         tsgroup = nap.TsGroup(group)
         sr_info = pd.Series(index=[1, 2, 3], data=[1, 1, 1], name="sr")


### PR DESCRIPTION
## Content
This PR solves issue #243 And also addresses most of the issues raised in #246.

### TsGroup Edits

#### **`__getattr__`  method added.**
Defined a  `__getattr__` that allows the following syntax,
  
```python
meta_data_series = tsgroup.name  # get the column "name" of `self._metadata` DataFrame
```
Raises an error if the name is not in the metadata.

#### **`__setitem__`  method modified.**
TsGroup is now mutable, but allowing only the metadata to change after initialization. The `__setitem__` allows only string as input, and enables,
```python
self._metadata[key] = values
```
Raises error if the key is non-string.

#### **`__getitem__`  method modified.**
The `__getitem__` of TsGroup  logic was modified as follows,

1. If one of the keys in `self.keys()` is passed, then the corresponding `Ts` is returned.
2. If the string is in the self._metadata.columns (hence it is a `str`, hence it is not in self.keys()), then it returns  self._metadata[key]
3. If it is a `bool` ArrayLike of dim 1 it returns a TsGroup including the Ts corresponding to `keys = np.where(bool_array)[0]`
4. If it is an `int`ArrayLike of dim 1 it returns a TsGroup including the Ts corresponding to the array entries.
5. Raises appropriate errors if none of the above conditions hold