### PR TITLE
Bumping 0.6.3

### DIFF
--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -9,6 +9,15 @@ In 2018, Francesco started neuroseries, a Python package built on Pandas. It was
 In 2021, Guillaume and other trainees in Adrien's lab decided to fork from neuroseries and started *pynapple*. The core of pynapple is largely built upon neuroseries. Some of the original changes to TSToolbox made by Luke were included in this package, especially the *time_support* property of all ts/tsd objects.
 
 
+0.6.3 (2024-04-17)
+------------------
+
+- Improving `__repr__` for all objects.
+- TsGroup `__getattr__` and `__setattr__` added to access metadata columns directly
+- TsGroup `__setitem__` now allows changes directly to metadata
+- TsGroup `__getitem__` returns column of metadata if passed as string
+
+
 0.6.2 (2024-04-04)
 ------------------
 

--- a/pynapple/__init__.py
+++ b/pynapple/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 from .core import IntervalSet, Ts, Tsd, TsdFrame, TsdTensor, TsGroup, TsIndex, config
 from .io import *
 from .process import *

--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -471,7 +471,7 @@ class BaseTsd(Base, NDArrayOperatorsMixin, abc.ABC):
         `norm` set to True normalizes the gaussian kernel to sum to 1.
 
         In the following example, a time series `tsd` with a sampling rate of 100 Hz
-        is convolved with a non-normalized gaussian kernel. The standard deviation is
+        is convolved with a gaussian kernel. The standard deviation is
         0.05 second and the windowsize is 2 second. When instantiating the gaussian kernel
         from scipy, it corresponds to parameters `M = 200` and `std=5`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pynapple"
-version = "0.6.2"
+version = "0.6.3"
 description = "PYthon Neural Analysis Package Pour Laboratoires d’Excellence"
 readme = "README.md"
 authors = [{ name = "Guillaume Viejo", email = "guillaume.viejo@gmail.com" }]

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/pynapple-org/pynapple',
-    version='v0.6.2',
+    version='v0.6.3',
     zip_safe=False,
     long_description_content_type='text/markdown',
     download_url='https://github.com/pynapple-org/pynapple/archive/refs/tags/v0.6.0.tar.gz'


### PR DESCRIPTION
- Improving `__repr__` for all objects.
- TsGroup `__getattr__` and `__setattr__` added to access metadata columns directly
- TsGroup `__setitem__` now allows changes directly to metadata
- TsGroup `__getitem__` returns column of metadata if passed as string
