### PR TITLE
Currently append_NWB_LFP function will not work with TsdFrames; this fixes.

### DIFF
--- a/pynapple/io/misc.py
+++ b/pynapple/io/misc.py
@@ -283,7 +283,7 @@ def append_NWB_LFP(path, lfp, channel=None):
         raise RuntimeError("Can't find nwb file in {}".format(path))
 
     if isinstance(lfp, nap.TsdFrame):
-        channels = lfp.columns.values
+        channels = list(lfp.columns.values)
     elif isinstance(lfp, nap.Tsd):
         if isinstance(channel, int):
             channels = [channel]


### PR DESCRIPTION
Should fix #297 

Currently append_NWB_LFP function will not work with TsdFrames; this fixes by casting ndarray to a list - otherwise, the ndarray will reach `nwbfile.create_electrode_table_region` which will error (as it requires slice or list or tuple).