### PR TITLE
IntervalSet creation from (start, end) pairs

### DIFF
--- a/pynapple/core/interval_set.py
+++ b/pynapple/core/interval_set.py
@@ -94,7 +94,7 @@ class IntervalSet(NDArrayOperatorsMixin):
 
         Parameters
         ----------
-        start : numpy.ndarray or number or pandas.DataFrame or pandas.Series
+        start : numpy.ndarray or number or pandas.DataFrame or pandas.Series or iterable of (start, end) pairs
             Beginning of intervals
         end : numpy.ndarray or number or pandas.Series, optional
             Ends of intervals
@@ -108,8 +108,8 @@ class IntervalSet(NDArrayOperatorsMixin):
 
         """
         if isinstance(start, IntervalSet):
-            end = start.values[:, 1].astype(np.float64)
-            start = start.values[:, 0].astype(np.float64)
+            end = start.end.astype(np.float64)
+            start = start.start.astype(np.float64)
 
         elif isinstance(start, pd.DataFrame):
             assert (
@@ -125,7 +125,16 @@ class IntervalSet(NDArrayOperatorsMixin):
             start = start["start"].values.astype(np.float64)
 
         else:
-            assert end is not None, "Missing end argument when initializing IntervalSet"
+            if end is None:
+                # Require iterable of (start, end) tuples
+                try:
+                    start_end_array = np.array(list(start))
+                    if start_end_array.ndim == 1:
+                        start, end = start_end_array
+                    else:
+                        start, end = zip(*start_end_array)
+                except (TypeError, ValueError):
+                    raise ValueError("Unable to Interpret the input. Please provide a list of start-end intervals.")
 
             args = {"start": start, "end": end}
 

--- a/pynapple/core/ts_group.py
+++ b/pynapple/core/ts_group.py
@@ -124,6 +124,14 @@ class TsGroup(UserDict):
 
         self._metadata = pd.DataFrame(index=self.index, columns=["rate"], dtype="float")
 
+        # If time_support is passed, all elements of data are restricted prior to init
+        if time_support is not None and not isinstance(time_support, IntervalSet):
+            try:
+                time_support = IntervalSet(time_support)
+            except Exception:
+                warnings.warn("time_support could not be converted to IntervalSet. Ignoring it.", stacklevel=2)
+                time_support = None
+
         # Transform elements to Ts/Tsd objects
         for k in self.index:
             if not isinstance(data[k], Base):

--- a/tests/test_interval_set.py
+++ b/tests/test_interval_set.py
@@ -78,6 +78,23 @@ def test_create_iset_from_mock_array():
     np.testing.assert_array_almost_equal(ep.start, start)
     np.testing.assert_array_almost_equal(ep.end, end)
 
+def test_create_iset_from_tuple():
+    start = 0
+    end = 5
+    ep = nap.IntervalSet((start, end))
+    assert isinstance(ep, nap.core.interval_set.IntervalSet)
+    np.testing.assert_array_almost_equal(start, ep.start[0])
+    np.testing.assert_array_almost_equal(end, ep.end[0])
+
+def test_create_iset_from_tuple_iter():
+    start = [0, 10, 16, 25]
+    end = [5, 15, 20, 40]
+    pairs = zip(start, end)
+    ep = nap.IntervalSet(pairs)
+    assert isinstance(ep, nap.core.interval_set.IntervalSet)
+    np.testing.assert_array_almost_equal(start, ep.start)
+    np.testing.assert_array_almost_equal(end, ep.end)
+
 def test_create_iset_from_unknown_format():    
     with pytest.raises(RuntimeError) as e:
         nap.IntervalSet(start="abc", end=[1, 2])

--- a/tests/test_ts_group.py
+++ b/tests/test_ts_group.py
@@ -90,6 +90,15 @@ class TestTsGroup1:
         assert np.all(first >= ep[0, 0])
         assert np.all(last <= ep[0, 1])
 
+    def test_create_ts_group_with_time_support_tuple(self, group):
+        ep = (0, 100)
+        tsgroup = nap.TsGroup(group, time_support=ep)
+        np.testing.assert_array_almost_equal(tsgroup.time_support, nap.IntervalSet(ep))
+        first = [tsgroup[i].index[0] for i in tsgroup]
+        last = [tsgroup[i].index[-1] for i in tsgroup]
+        assert np.all(first >= np.float64(ep[0]))
+        assert np.all(last <= np.float64(ep[1]))
+
     def test_create_ts_group_with_empty_time_support(self):
         with pytest.raises(RuntimeError) as e_info:
             tmp = nap.TsGroup({


### PR DESCRIPTION
It's a bit counter-intuitive sometimes to split up a sequence of intervals into the starts and ends, and easier sometimes to write a sequence of start-end pairs. This change allows the `IntervalSet` to accept such a sequence of pairs, or a single pair.

Example:
```
single_intvl = IntervalSet((0, 60))
several_intvls = IntervalSet([(0, 5), (5, 10), (40, 50)])
```

I added tests and updated the doc string. This is my first PR to the repo, so more than happy for feedback on:
 - whether this sort of behavior is desired; my tendency might be toward more flexibility than other authors prefer
 - code style and practices
 - PR style and practices
 - anything else!
