### PR TITLE
Create a TsGroup from an iterable of Ts/Tsd objects

### DIFF
--- a/pynapple/core/ts_group.py
+++ b/pynapple/core/ts_group.py
@@ -138,6 +138,7 @@ class TsGroup(UserDict):
 
         data = {keys[j]: data[k] for j, k in enumerate(data.keys())}
         self.index = np.sort(keys)
+        data = {k: data[k] for k in self.index}  # Make sure data dict and index are ordered the same
 
         self._metadata = pd.DataFrame(index=self.index, columns=["rate"], dtype="float")
 

--- a/pynapple/core/ts_group.py
+++ b/pynapple/core/ts_group.py
@@ -75,9 +75,9 @@ class TsGroup(UserDict):
 
         Parameters
         ----------
-        data : dict
-            Dictionary containing Ts/Tsd objects, keys should contain integer values or should be convertible
-            to integer.
+        data : dict or iterable
+            Dictionary or iterable of Ts/Tsd objects. The keys should be integer-convertible; if a non-dict iterator is
+            passed, its values will be used to create a dict with integer keys.
         time_support : IntervalSet, optional
             The time support of the TsGroup. Ts/Tsd objects will be restricted to the time support if passed.
             If no time support is specified, TsGroup will merge time supports from all the Ts/Tsd objects in data.
@@ -117,13 +117,16 @@ class TsGroup(UserDict):
 
         self._initialized = False
 
+        if not isinstance(data, dict):
+            data = dict(enumerate(data))
+
         # convert all keys to integer
         try:
             keys = [int(k) for k in data.keys()]
         except Exception:
             raise ValueError("All keys must be convertible to integer.")
 
-        # check that there were no floats with decimal points in keys.i
+        # check that there were no floats with decimal points in keys.
         # i.e. 0.5 is not a valid key
         if not all(np.allclose(keys[j], float(k)) for j, k in enumerate(data.keys())):
             raise ValueError("All keys must have integer value!}")

--- a/pynapple/core/ts_group.py
+++ b/pynapple/core/ts_group.py
@@ -138,7 +138,8 @@ class TsGroup(UserDict):
 
         data = {keys[j]: data[k] for j, k in enumerate(data.keys())}
         self.index = np.sort(keys)
-        data = {k: data[k] for k in self.index}  # Make sure data dict and index are ordered the same
+        # Make sure data dict and index are ordered the same
+        data = {k: data[k] for k in self.index}
 
         self._metadata = pd.DataFrame(index=self.index, columns=["rate"], dtype="float")
 

--- a/tests/test_ts_group.py
+++ b/tests/test_ts_group.py
@@ -51,10 +51,19 @@ class TestTsGroup1:
         assert isinstance(tsgroup, UserDict)
         assert len(tsgroup) == 3
 
+    def test_create_ts_group_from_iter(self, group):
+        tsgroup = nap.TsGroup(group.values())
+        assert isinstance(tsgroup, UserDict)
+        assert len(tsgroup) == 3
+
+    def test_create_ts_group_from_invalid(self):
+        with pytest.raises(AttributeError):
+            tsgroup = nap.TsGroup(np.arange(0, 200))
+
     @pytest.mark.parametrize(
         "test_dict, expectation",
         [
-            ({"1": nap.Ts(np.arange(10)), "2":nap.Ts(np.arange(10))}, does_not_raise()),
+            ({"1": nap.Ts(np.arange(10)), "2": nap.Ts(np.arange(10))}, does_not_raise()),
             ({"1": nap.Ts(np.arange(10)), 2: nap.Ts(np.arange(10))}, does_not_raise()),
             ({"1": nap.Ts(np.arange(10)), 1: nap.Ts(np.arange(10))},
              pytest.raises(ValueError, match="Two dictionary keys contain the same integer")),
@@ -81,7 +90,6 @@ class TestTsGroup1:
     )
     def test_metadata_len_match(self, tsgroup):
         assert len(tsgroup._metadata) == len(tsgroup)
-
 
     def test_create_ts_group_from_array(self):
         with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
It doesn't seem to make a ton of sense to me to require that users manually package their timestamp/series objects into a dict when creating `TsGroup` objects, since the keys are required to be unique integers. I would guess that the vast majority of the time, users would be just doing `{0: ts0, 1: ts1, ...}`. Sure, this can be easily done by saying `data = dict(enumerate(ts_list))`, but why not just allow the user to say `data = ts_list` and do the dict creation automatically?

If the change described above is not desired, the second commit is probably still worth including. It ensures that the keys in `.data` and `.index` are in the same order by doing this:
```
data = {k: data[k] for k in self.index}
```
This might not be assured if `bypass_check == True`.

I added some tests for the new functionality. Again, any and all feedback/concerns/thoughts are welcome!