### PR TITLE
Pickling tsgroup

### DIFF
--- a/pynapple/core/ts_group.py
+++ b/pynapple/core/ts_group.py
@@ -202,6 +202,10 @@ class TsGroup(UserDict):
         AttributeError
             If the requested attribute is not a metadata column.
         """
+        # avoid infinite recursion when pickling due to
+        # self._metadata.column having attributes '__reduce__', '__reduce_ex__'
+        if name in ('__getstate__', '__setstate__', '__reduce__', '__reduce_ex__'):
+            raise AttributeError(name)
         # Check if the requested attribute is part of the metadata
         if name in self._metadata.columns:
             return self._metadata[name]

--- a/pynapple/core/ts_group.py
+++ b/pynapple/core/ts_group.py
@@ -204,7 +204,7 @@ class TsGroup(UserDict):
         """
         # avoid infinite recursion when pickling due to
         # self._metadata.column having attributes '__reduce__', '__reduce_ex__'
-        if name in ('__getstate__', '__setstate__', '__reduce__', '__reduce_ex__'):
+        if name in ("__getstate__", "__setstate__", "__reduce__", "__reduce_ex__"):
             raise AttributeError(name)
         # Check if the requested attribute is part of the metadata
         if name in self._metadata.columns:

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -1,10 +1,12 @@
 """Tests of time series for `pynapple` package."""
 
-import pynapple as nap
+import pickle
+
 import numpy as np
 import pandas as pd
 import pytest
 
+import pynapple as nap
 
 # tsd1 = nap.Tsd(t=np.arange(100), d=np.random.rand(100), time_units="s")
 # tsd2 = nap.TsdFrame(t=np.arange(100), d=np.random.rand(100, 3), columns = ['a', 'b', 'c'])
@@ -1444,3 +1446,25 @@ class Test_Time_Series_5:
         tsdframe2 = tsdtensor.interpolate(ts, ep)
         assert len(tsdframe2) == 0
 
+@pytest.mark.parametrize("obj",
+                         [
+                             nap.Tsd(t=np.arange(10), d=np.random.rand(10), time_units="s"),
+                             nap.TsdFrame(
+                                 t=np.arange(10), d=np.random.rand(10, 3), time_units="s", columns=["a","b","c"]
+                             ),
+                             nap.TsdTensor(t=np.arange(10), d=np.random.rand(10, 3, 2), time_units="s"),
+                         ])
+def test_pickling(obj):
+    """Test that pikling works as expected."""
+    # pickle and unpickle ts_group
+    pickled_obj = pickle.dumps(obj)
+    unpickled_obj = pickle.loads(pickled_obj)
+
+    # Ensure time is the same
+    assert np.all(obj.t == unpickled_obj.t)
+
+    # Ensure data is the same
+    assert np.all(obj.d == unpickled_obj.d)
+
+    # Ensure time support is the same
+    assert np.all(obj.time_support == unpickled_obj.time_support)

--- a/tests/test_ts_group.py
+++ b/tests/test_ts_group.py
@@ -6,13 +6,17 @@
 
 """Tests of ts group for `pynapple` package."""
 
-import pynapple as nap
+import pickle
+import warnings
+from collections import UserDict
+from contextlib import nullcontext as does_not_raise
+
 import numpy as np
 import pandas as pd
 import pytest
-from collections import UserDict
-import warnings
-from contextlib import nullcontext as does_not_raise
+
+import pynapple as nap
+
 
 @pytest.fixture
 def group():
@@ -855,3 +859,28 @@ class TestTsGroup1:
                 ts_group.time_support.as_units("s").to_numpy(),
                 merged.time_support.as_units("s").to_numpy()
                 )
+
+
+def test_pickling(ts_group):
+    """Test that pikling works as expected."""
+    # pickle and unpickle ts_group
+    pickled_obj = pickle.dumps(ts_group)
+    unpickled_obj = pickle.loads(pickled_obj)
+
+    # Ensure the type is the same
+    assert type(ts_group) is type(unpickled_obj), "Types are different"
+
+    # Ensure that TsGroup have same len
+    assert len(ts_group) == len(unpickled_obj)
+
+    # Ensure that metadata content is the same
+    assert np.all(unpickled_obj._metadata == ts_group._metadata)
+
+    # Ensure that metadata columns are the same
+    assert np.all(unpickled_obj._metadata.columns == ts_group._metadata.columns)
+
+    # Ensure that the Ts are the same
+    assert all([np.all(ts_group[key].t == unpickled_obj[key].t) for key in unpickled_obj.keys()])
+
+    # Ensure time support is the same
+    assert np.all(ts_group.time_support == unpickled_obj.time_support)


### PR DESCRIPTION
## Description

This PR solves the issue of infinite recursion for the pickling of "TsGroup".

Raises an error if `__getattr__` is called by the `__reduce__` and `__reduce_ex__` methods. 

These are attributes of the `pandas.Index`, which are the column names of the metadata, that would be called by captured by the `__getattr__` implementation otherwise, generating an infinite recursion.

## New Capability
This two line now do not generate an infinite recursion.

```python
import pickle
#...assume tsgroup is a TsGroup
pickled_tsgroup = pickle.dumps(tsgroup)
unpickled_tsgroup = pickle.loads(pickled_tsgroup)
```