### PR TITLE
Os removal

### DIFF
--- a/pynapple/core/base_class.py
+++ b/pynapple/core/base_class.py
@@ -11,7 +11,7 @@ import numpy as np
 from ._core_functions import _count, _restrict, _value_from
 from .interval_set import IntervalSet
 from .time_index import TsIndex
-from .utils import convert_to_numpy_array
+from .utils import check_filename, convert_to_numpy_array
 
 
 class Base(abc.ABC):
@@ -425,6 +425,27 @@ class Base(abc.ABC):
             idx_start = np.searchsorted(time_array, start)
             idx_end = np.searchsorted(time_array, end, side="right")
             return self[idx_start:idx_end]
+
+    def _get_filename(self, filename):
+        """Check if the filename is valid and return the path
+
+        Parameters
+        ----------
+        filename : str or Path
+            The filename
+
+        Returns
+        -------
+        Path
+            The path to the file
+
+        Raises
+        ------
+        RuntimeError
+            If the filename is a directory or the parent does not exist
+        """
+
+        return check_filename(filename)
 
     @classmethod
     def _from_npz_reader(cls, file):

--- a/pynapple/core/interval_set.py
+++ b/pynapple/core/interval_set.py
@@ -40,7 +40,6 @@
 """
 
 import importlib
-import os
 import warnings
 from numbers import Number
 
@@ -61,6 +60,7 @@ from .time_index import TsIndex
 from .utils import (
     _get_terminal_size,
     _IntervalSetSliceHelper,
+    check_filename,
     convert_to_numpy_array,
     is_array_like,
 )
@@ -643,26 +643,8 @@ class IntervalSet(NDArrayOperatorsMixin):
         RuntimeError
             If filename is not str, path does not exist or filename is a directory.
         """
-        if not isinstance(filename, str):
-            raise RuntimeError("Invalid type; please provide filename as string")
-
-        if os.path.isdir(filename):
-            raise RuntimeError(
-                "Invalid filename input. {} is directory.".format(filename)
-            )
-
-        if not filename.lower().endswith(".npz"):
-            filename = filename + ".npz"
-
-        dirname = os.path.dirname(filename)
-
-        if len(dirname) and not os.path.exists(dirname):
-            raise RuntimeError(
-                "Path {} does not exist.".format(os.path.dirname(filename))
-            )
-
         np.savez(
-            filename,
+            check_filename(filename),
             start=self.values[:, 0],
             end=self.values[:, 1],
             type=np.array(["IntervalSet"], dtype=np.str_),

--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -17,7 +17,6 @@
 
 import abc
 import importlib
-import os
 import warnings
 from numbers import Number
 
@@ -830,23 +829,7 @@ class TsdTensor(BaseTsd):
         RuntimeError
             If filename is not str, path does not exist or filename is a directory.
         """
-        if not isinstance(filename, str):
-            raise RuntimeError("Invalid type; please provide filename as string")
-
-        if os.path.isdir(filename):
-            raise RuntimeError(
-                "Invalid filename input. {} is directory.".format(filename)
-            )
-
-        if not filename.lower().endswith(".npz"):
-            filename = filename + ".npz"
-
-        dirname = os.path.dirname(filename)
-
-        if len(dirname) and not os.path.exists(dirname):
-            raise RuntimeError(
-                "Path {} does not exist.".format(os.path.dirname(filename))
-            )
+        filename = self._get_filename(filename)
 
         np.savez(
             filename,
@@ -1110,23 +1093,7 @@ class TsdFrame(BaseTsd):
         RuntimeError
             If filename is not str, path does not exist or filename is a directory.
         """
-        if not isinstance(filename, str):
-            raise RuntimeError("Invalid type; please provide filename as string")
-
-        if os.path.isdir(filename):
-            raise RuntimeError(
-                "Invalid filename input. {} is directory.".format(filename)
-            )
-
-        if not filename.lower().endswith(".npz"):
-            filename = filename + ".npz"
-
-        dirname = os.path.dirname(filename)
-
-        if len(dirname) and not os.path.exists(dirname):
-            raise RuntimeError(
-                "Path {} does not exist.".format(os.path.dirname(filename))
-            )
+        filename = self._get_filename(filename)
 
         cols_name = self.columns
         if cols_name.dtype == np.dtype("O"):
@@ -1437,24 +1404,7 @@ class Tsd(BaseTsd):
         RuntimeError
             If filename is not str, path does not exist or filename is a directory.
         """
-        if not isinstance(filename, str):
-            raise RuntimeError("Invalid type; please provide filename as string")
-
-        if os.path.isdir(filename):
-            raise RuntimeError(
-                "Invalid filename input. {} is directory.".format(filename)
-            )
-
-        if not filename.lower().endswith(".npz"):
-            filename = filename + ".npz"
-
-        dirname = os.path.dirname(filename)
-
-        if len(dirname) and not os.path.exists(dirname):
-            raise RuntimeError(
-                "Path {} does not exist.".format(os.path.dirname(filename))
-            )
-
+        filename = self._get_filename(filename)
         np.savez(
             filename,
             t=self.index.values,
@@ -1730,23 +1680,7 @@ class Ts(Base):
         RuntimeError
             If filename is not str, path does not exist or filename is a directory.
         """
-        if not isinstance(filename, str):
-            raise RuntimeError("Invalid type; please provide filename as string")
-
-        if os.path.isdir(filename):
-            raise RuntimeError(
-                "Invalid filename input. {} is directory.".format(filename)
-            )
-
-        if not filename.lower().endswith(".npz"):
-            filename = filename + ".npz"
-
-        dirname = os.path.dirname(filename)
-
-        if len(dirname) and not os.path.exists(dirname):
-            raise RuntimeError(
-                "Path {} does not exist.".format(os.path.dirname(filename))
-            )
+        filename = self._get_filename(filename)
 
         np.savez(
             filename,

--- a/pynapple/core/ts_group.py
+++ b/pynapple/core/ts_group.py
@@ -4,7 +4,6 @@
 
 """
 
-import os
 import warnings
 from collections import UserDict
 from collections.abc import Hashable
@@ -21,7 +20,7 @@ from .config import nap_config
 from .interval_set import IntervalSet
 from .time_index import TsIndex
 from .time_series import BaseTsd, Ts, Tsd, TsdFrame, is_array_like
-from .utils import _get_terminal_size, convert_to_numpy_array
+from .utils import _get_terminal_size, check_filename, convert_to_numpy_array
 
 
 def _union_intervals(i_sets):
@@ -1325,23 +1324,7 @@ class TsGroup(UserDict):
         RuntimeError
             If filename is not str, path does not exist or filename is a directory.
         """
-        if not isinstance(filename, str):
-            raise RuntimeError("Invalid type; please provide filename as string")
-
-        if os.path.isdir(filename):
-            raise RuntimeError(
-                "Invalid filename input. {} is directory.".format(filename)
-            )
-
-        if not filename.lower().endswith(".npz"):
-            filename = filename + ".npz"
-
-        dirname = os.path.dirname(filename)
-
-        if len(dirname) and not os.path.exists(dirname):
-            raise RuntimeError(
-                "Path {} does not exist.".format(os.path.dirname(filename))
-            )
+        filename = check_filename(filename)
 
         dicttosave = {"type": np.array(["TsGroup"], dtype=np.str_)}
         for k in self._metadata.columns:

--- a/pynapple/core/utils.py
+++ b/pynapple/core/utils.py
@@ -6,6 +6,7 @@ import os
 import warnings
 from itertools import combinations
 from numbers import Number
+from pathlib import Path
 
 import numpy as np
 
@@ -403,3 +404,35 @@ class _IntervalSetSliceHelper:
                     raise IndexError
             else:
                 raise IndexError
+
+
+def check_filename(filename):
+    """Check if the filename is valid and return the path
+
+    Parameters
+    ----------
+    filename : str or Path
+        The filename
+
+    Returns
+    -------
+    Path
+        The path to the file
+
+    Raises
+    ------
+    RuntimeError
+        If the filename is a directory or the parent does not exist
+    """
+    filename = Path(filename).resolve()
+
+    if filename.is_dir():
+        raise RuntimeError("Invalid filename input. {} is directory.".format(filename))
+
+    filename = filename.with_suffix(".npz")
+
+    parent_folder = filename.parent
+    if not parent_folder.exists():
+        raise RuntimeError("Path {} does not exist.".format(parent_folder))
+
+    return filename

--- a/pynapple/io/cnmfe.py
+++ b/pynapple/io/cnmfe.py
@@ -11,7 +11,7 @@ Support CNMF-E in matlab, inscopix-cnmfe and minian.
 # @Last Modified by:   gviejo
 # @Last Modified time: 2023-11-16 13:14:54
 
-import os
+from pathlib import Path
 
 from pynwb import NWBHDF5IO
 
@@ -43,13 +43,14 @@ class CNMF_E(BaseLoader):
         path : str
             The path to the data.
         """
-        self.basename = os.path.basename(path)
+        path = Path(path)
+        self.basename = path.name
 
         super().__init__(path)
 
-        self.load_cnmfe_nwb(path)
+        self.load_cnmfe_nwb()
 
-    def load_cnmfe_nwb(self, path):
+    def load_cnmfe_nwb(self):
         """
         Load the calcium transient and spatial footprint from nwb
 
@@ -58,13 +59,6 @@ class CNMF_E(BaseLoader):
         path : str
             Path to the session
         """
-        self.nwb_path = os.path.join(path, "pynapplenwb")
-        if not os.path.exists(self.nwb_path):
-            raise RuntimeError("Path {} does not exist.".format(self.nwb_path))
-
-        self.nwbfilename = [f for f in os.listdir(self.nwb_path) if "nwb" in f][0]
-        self.nwbfilepath = os.path.join(self.nwb_path, self.nwbfilename)
-
         io = NWBHDF5IO(self.nwbfilepath, "r")
         nwbfile = io.read()
 
@@ -110,13 +104,14 @@ class Minian(BaseLoader):
         path : str
             The path to the data.
         """
-        self.basename = os.path.basename(path)
+        path = Path(path)
+        self.basename = path.name
 
         super().__init__(path)
 
-        self.load_cnmfe_nwb(path)
+        self.load_cnmfe_nwb()
 
-    def load_cnmfe_nwb(self, path):
+    def load_cnmfe_nwb(self):
         """
         Load the calcium transient and spatial footprint from nwb
 
@@ -125,13 +120,6 @@ class Minian(BaseLoader):
         path : str
             Path to the session
         """
-        self.nwb_path = os.path.join(path, "pynapplenwb")
-        if not os.path.exists(self.nwb_path):
-            raise RuntimeError("Path {} does not exist.".format(self.nwb_path))
-
-        self.nwbfilename = [f for f in os.listdir(self.nwb_path) if "nwb" in f][0]
-        self.nwbfilepath = os.path.join(self.nwb_path, self.nwbfilename)
-
         io = NWBHDF5IO(self.nwbfilepath, "r")
         nwbfile = io.read()
 
@@ -178,13 +166,14 @@ class InscopixCNMFE(BaseLoader):
         path : str
             The path to the data.
         """
-        self.basename = os.path.basename(path)
+        path = Path(path)
+        self.basename = path.name
 
         super().__init__(path)
 
-        self.load_cnmfe_nwb(path)
+        self.load_cnmfe_nwb()
 
-    def load_cnmfe_nwb(self, path):
+    def load_cnmfe_nwb(self):
         """
         Load the calcium transient and spatial footprint from nwb
 
@@ -193,13 +182,6 @@ class InscopixCNMFE(BaseLoader):
         path : str
             Path to the session
         """
-        self.nwb_path = os.path.join(path, "pynapplenwb")
-        if not os.path.exists(self.nwb_path):
-            raise RuntimeError("Path {} does not exist.".format(self.nwb_path))
-
-        self.nwbfilename = [f for f in os.listdir(self.nwb_path) if "nwb" in f][0]
-        self.nwbfilepath = os.path.join(self.nwb_path, self.nwbfilename)
-
         io = NWBHDF5IO(self.nwbfilepath, "r")
         nwbfile = io.read()
 

--- a/pynapple/io/folder.py
+++ b/pynapple/io/folder.py
@@ -12,10 +12,10 @@ The Folder class helps to navigate a hierarchical data tree.
 
 
 import json
-import os
 import string
 from collections import UserDict
 from datetime import datetime
+from pathlib import Path
 
 from rich.console import Console  # , ConsoleOptions, RenderResult
 from rich.panel import Panel
@@ -30,27 +30,29 @@ def _find_files(path, extension=".npz"):
 
     Parameters
     ----------
-    path : TYPE
-        Description
+    path : str or Path
+        The directory path where files will be searched.
     extension : str, optional
-        Description
+        The file extension to look for, default is ".npz".
 
     Returns
     -------
-    TYPE
-        Description
+    dict
+        Dictionary with filenames (without extension and whitespace) as keys
+        and NPZFile or NWBFile objects as values.
     """
+    extension = extension if extension.startswith(".") else "." + extension
+    path = Path(path)  # Ensure path is a Path object
     files = {}
-    for f in os.scandir(path):
-        if f.is_file() and f.name.endswith(extension):
-            if extension == "npz":
-                filename = os.path.splitext(os.path.basename(f.path))[0]
-                filename.translate({ord(c): None for c in string.whitespace})
-                files[filename] = NPZFile(f.path)
-            elif extension == "nwb":
-                filename = os.path.splitext(os.path.basename(f.path))[0]
-                filename.translate({ord(c): None for c in string.whitespace})
-                files[filename] = NWBFile(f.path)
+    extensions_dict = {".npz": NPZFile, ".nwb": NWBFile}
+    assert extension in extensions_dict.keys(), f"Extension {extension} not supported"
+
+    for f in path.iterdir():
+        if f.is_file() and f.suffix == extension:
+            filename = f.stem
+            filename = filename.translate({ord(c): None for c in string.whitespace})
+            files[filename] = extensions_dict[extension](f)
+
     return files
 
 
@@ -108,9 +110,9 @@ class Folder(UserDict):
         path : str
             Path to the folder
         """
-        path = path.rstrip("/")
+        path = Path(path)
         self.path = path
-        self.name = os.path.basename(path)
+        self.name = self.path.name
         self._basic_view = Tree(
             ":open_file_folder: {}".format(self.name), guide_style="blue"
         )
@@ -118,16 +120,15 @@ class Folder(UserDict):
 
         # Search sub-folders
         subfolds = [
-            f.path
-            for f in os.scandir(path)
-            if f.is_dir() and not f.name.startswith(".")
+            p for p in path.iterdir() if p.is_dir() and not p.name.startswith(".")
         ]
+
         subfolds.sort()
 
         self.subfolds = {}
 
         for s in subfolds:
-            sub = os.path.basename(s)
+            sub = s.name
             self.subfolds[sub] = Folder(s)
             self._basic_view.add(":open_file_folder: [blue]" + sub)
 
@@ -244,14 +245,14 @@ class Folder(UserDict):
         description : str, optional
             Metainformation added as a json sidecar.
         """
-        filepath = os.path.join(self.path, name)
+        filepath = self.path / (name + ".npz")
         obj.save(filepath)
-        self.npz_files[name] = NPZFile(filepath + ".npz")
+        self.npz_files[name] = NPZFile(filepath)
         self.data[name] = obj
 
         metadata = {"time": str(datetime.now()), "info": str(description)}
 
-        with open(os.path.join(self.path, name + ".json"), "w") as ff:
+        with open(self.path / (name + ".json"), "w") as ff:
             json.dump(metadata, ff, indent=2)
 
         # regenerate the tree view
@@ -295,19 +296,18 @@ class Folder(UserDict):
             Name of the npz file
         """
         # Search for json first
-        json_filename = os.path.join(self.path, name + ".json")
-        if os.path.isfile(json_filename):
+        json_filename = self.path / (name + ".json")
+        title = self.path / (name + ".npz")
+        if json_filename.exists():
             with open(json_filename, "r") as ff:
                 metadata = json.load(ff)
                 text = "\n".join([" : ".join(it) for it in metadata.items()])
-            panel = Panel.fit(
-                text, border_style="green", title=os.path.join(self.path, name + ".npz")
-            )
+            panel = Panel.fit(text, border_style="green", title=title)
         else:
             panel = Panel.fit(
                 "No metadata",
                 border_style="red",
-                title=os.path.join(self.path, name + ".npz"),
+                title=title,
             )
         with Console() as console:
             console.print(panel)

--- a/pynapple/io/interface_npz.py
+++ b/pynapple/io/interface_npz.py
@@ -7,7 +7,7 @@
 # @Last Modified time: 2024-04-02 14:32:25
 
 
-import os
+from pathlib import Path
 
 import numpy as np
 
@@ -63,8 +63,9 @@ class NPZFile(object):
         path : str
             Valid path to a NPZ file
         """
+        path = Path(path)
         self.path = path
-        self.name = os.path.basename(path)
+        self.name = path.name
         self.file = np.load(self.path, allow_pickle=True)
         type_ = ""
 

--- a/pynapple/io/loader.py
+++ b/pynapple/io/loader.py
@@ -10,6 +10,7 @@ BaseLoader is the general class for loading session with pynapple.
 @author: Guillaume Viejo
 """
 import os
+from pathlib import Path
 import warnings
 
 import pandas as pd
@@ -56,23 +57,26 @@ class BaseLoader(object):
     """
 
     def __init__(self, path=None):
-        self.path = path
+        self.path = Path(path)
 
-        file_found = False
         # Check if a pynapplenwb folder exist
-        if self.path is not None:
-            nwb_path = os.path.join(self.path, "pynapplenwb")
-            if os.path.exists(nwb_path):
-                files = os.listdir(nwb_path)
-                if len([f for f in files if f.endswith(".nwb")]):
-                    file_found = True
-                    self.load_data(path)
-
-        # Starting the GUI
-        if not file_found:
+        nwb_path = self.path / "pynapplenwb"
+        files = list(nwb_path.glob("*.nwb"))
+        
+        if len(files) > 0:
+            self.load_data()
+        else:
             raise RuntimeError(get_error_text(path))
+        
+    @property
+    def nwbfilepath(self):
+        try:
+            nwbfilepath = next(self.path.glob("pynapplenwb/*nwb"))
+        except StopIteration:
+            raise FileNotFoundError("No NWB file found in {}".format(self.path / "pynapplenwb"))
+        return nwbfilepath
 
-    def load_data(self, path):
+    def load_data(self):
         """
         Load NWB data saved with pynapple in the pynapplenwb folder
 
@@ -81,11 +85,6 @@ class BaseLoader(object):
         path : str
             Path to the session folder
         """
-        self.nwb_path = os.path.join(path, "pynapplenwb")
-        if not os.path.exists(self.nwb_path):
-            raise RuntimeError("Path {} does not exist.".format(self.nwb_path))
-        self.nwbfilename = [f for f in os.listdir(self.nwb_path) if "nwb" in f][0]
-        self.nwbfilepath = os.path.join(self.nwb_path, self.nwbfilename)
 
         io = NWBHDF5IO(self.nwbfilepath, "r+")
         nwbfile = io.read()

--- a/pynapple/io/loader.py
+++ b/pynapple/io/loader.py
@@ -10,8 +10,8 @@ BaseLoader is the general class for loading session with pynapple.
 @author: Guillaume Viejo
 """
 import os
-from pathlib import Path
 import warnings
+from pathlib import Path
 
 import pandas as pd
 from pynwb import NWBHDF5IO, TimeSeries
@@ -62,18 +62,20 @@ class BaseLoader(object):
         # Check if a pynapplenwb folder exist
         nwb_path = self.path / "pynapplenwb"
         files = list(nwb_path.glob("*.nwb"))
-        
+
         if len(files) > 0:
             self.load_data()
         else:
             raise RuntimeError(get_error_text(path))
-        
+
     @property
     def nwbfilepath(self):
         try:
             nwbfilepath = next(self.path.glob("pynapplenwb/*nwb"))
         except StopIteration:
-            raise FileNotFoundError("No NWB file found in {}".format(self.path / "pynapplenwb"))
+            raise FileNotFoundError(
+                "No NWB file found in {}".format(self.path / "pynapplenwb")
+            )
         return nwbfilepath
 
     def load_data(self):

--- a/pynapple/io/neurosuite.py
+++ b/pynapple/io/neurosuite.py
@@ -12,7 +12,8 @@ Class and functions for loading data processed with the Neurosuite (Klusters, Ne
 
 @author: Guillaume Viejo
 """
-import os
+# import os
+from pathlib import Path
 import sys
 
 import numpy as np
@@ -37,14 +38,15 @@ class NeuroSuite(BaseLoader):
         path : str
             The path to the data.
         """
-        self.basename = os.path.basename(path)
+        path = Path(path)
+        self.basename = path.name
         self.time_support = None
 
         super().__init__(path)
 
-        self.load_nwb_spikes(path)
+        self.load_nwb_spikes()
 
-    def load_nwb_spikes(self, path):
+    def load_nwb_spikes(self):
         """
         Read the NWB spikes to extract the spike times.
 
@@ -58,11 +60,6 @@ class NeuroSuite(BaseLoader):
         TYPE
             Description
         """
-        self.nwb_path = os.path.join(path, "pynapplenwb")
-        if not os.path.exists(self.nwb_path):
-            raise RuntimeError("Path {} does not exist.".format(self.nwb_path))
-        self.nwbfilename = [f for f in os.listdir(self.nwb_path) if "nwb" in f][0]
-        self.nwbfilepath = os.path.join(self.nwb_path, self.nwbfilename)
 
         io = NWBHDF5IO(self.nwbfilepath, "r")
         nwbfile = io.read()
@@ -129,16 +126,16 @@ class NeuroSuite(BaseLoader):
             The lfp in a time series format
         """
         if filename is not None:
-            filepath = os.path.join(self.path, filename)
+            filepath = self.path / filename
         else:
-            listdir = os.listdir(self.path)
-            eegfile = [f for f in listdir if f.endswith(extension)]
+            eegfile = list(filepath.glob(f"*{extension}"))
+
             if not len(eegfile):
                 raise RuntimeError(
                     "Path {} contains no {} files;".format(self.path, extension)
                 )
 
-            filepath = os.path.join(self.path, eegfile[0])
+            filepath = eegfile[0]
 
         self.load_neurosuite_xml(self.path)
 
@@ -200,9 +197,10 @@ class NeuroSuite(BaseLoader):
             isets = self.load_nwb_intervals(name)
             if isinstance(isets, nap.IntervalSet):
                 return isets
+        
         if name is not None and path2file is None:
-            path2file = os.path.join(self.path, self.basename + "." + name + ".evt")
-        if path2file is not None:
+            path2file = self.path / self.basename + "." + name + ".evt"
+        if path2file is not None:  #TODO maybe useless conditional?
             try:
                 # df = pd.read_csv(path2file, delimiter=' ', usecols = [0], header = None)
                 tmp = np.genfromtxt(path2file)[:, 0]
@@ -244,7 +242,7 @@ class NeuroSuite(BaseLoader):
             )
         ).T.flatten()
 
-        evt_file = os.path.join(self.path, self.basename + extension)
+        evt_file = self.path / (self.basename + extension)
 
         f = open(evt_file, "w")
         for t, n in zip(datatowrite, texttowrite):
@@ -281,7 +279,7 @@ class NeuroSuite(BaseLoader):
             waveform_window = nap.IntervalSet(start=-0.5, end=1, time_units="ms")
 
         spikes = self.spikes
-        if not os.path.exists(self.path):  # check if path exists
+        if not self.path.exists():  # check if path exists
             print("The path " + self.path + " doesn't exist; Exiting ...")
             sys.exit()
 
@@ -304,11 +302,12 @@ class NeuroSuite(BaseLoader):
                 epend = int(epoch.as_units("s")["end"].values[0] * fs)
 
         # Find dat file
-        files = os.listdir(self.path)
-        dat_files = np.sort([f for f in files if "dat" in f and f[0] != "."])
+        #files = os.listdir(self.path)
+       #  dat_files = np.sort([f for f in files if "dat" in f and f[0] != "."])
 
         # Need n_samples collected in the entire recording from dat file to load
-        file = os.path.join(self.path, dat_files[0])
+        # file = self.path / dat_files[0]
+        file = next(self.path.glob("^[^.][^.]*.dat"))
         f = open(
             file, "rb"
         )  # open file to get number of samples collected in the entire recording

--- a/pynapple/io/neurosuite.py
+++ b/pynapple/io/neurosuite.py
@@ -12,9 +12,8 @@ Class and functions for loading data processed with the Neurosuite (Klusters, Ne
 
 @author: Guillaume Viejo
 """
-# import os
-from pathlib import Path
 import sys
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -197,10 +196,10 @@ class NeuroSuite(BaseLoader):
             isets = self.load_nwb_intervals(name)
             if isinstance(isets, nap.IntervalSet):
                 return isets
-        
+
         if name is not None and path2file is None:
             path2file = self.path / self.basename + "." + name + ".evt"
-        if path2file is not None:  #TODO maybe useless conditional?
+        if path2file is not None:  # TODO maybe useless conditional?
             try:
                 # df = pd.read_csv(path2file, delimiter=' ', usecols = [0], header = None)
                 tmp = np.genfromtxt(path2file)[:, 0]
@@ -302,8 +301,8 @@ class NeuroSuite(BaseLoader):
                 epend = int(epoch.as_units("s")["end"].values[0] * fs)
 
         # Find dat file
-        #files = os.listdir(self.path)
-       #  dat_files = np.sort([f for f in files if "dat" in f and f[0] != "."])
+        # files = os.listdir(self.path)
+        #  dat_files = np.sort([f for f in files if "dat" in f and f[0] != "."])
 
         # Need n_samples collected in the entire recording from dat file to load
         # file = self.path / dat_files[0]

--- a/pynapple/io/phy.py
+++ b/pynapple/io/phy.py
@@ -7,6 +7,7 @@ Class and functions for loading data processed with Phy2
 """
 
 from pathlib import Path
+
 import numpy as np
 from pynwb import NWBHDF5IO
 

--- a/pynapple/io/phy.py
+++ b/pynapple/io/phy.py
@@ -6,8 +6,7 @@ Class and functions for loading data processed with Phy2
 @author: Sara Mahallati, Guillaume Viejo
 """
 
-import os
-
+from pathlib import Path
 import numpy as np
 from pynwb import NWBHDF5IO
 
@@ -29,14 +28,16 @@ class Phy(BaseLoader):
         path : str or Path object
             The path to the data.
         """
-        self.basename = os.path.basename(path)
+        path = Path(path)
+
+        self.basename = path.name
         self.time_support = None
 
         super().__init__(path)
 
-        self.load_nwb_spikes(path)
+        self.load_nwb_spikes()
 
-    def load_nwb_spikes(self, path):
+    def load_nwb_spikes(self):
         """Read the NWB spikes to extract the spike times.
 
         Returns
@@ -44,11 +45,6 @@ class Phy(BaseLoader):
         TYPE
             Description
         """
-        self.nwb_path = os.path.join(path, "pynapplenwb")
-        if not os.path.exists(self.nwb_path):
-            raise RuntimeError("Path {} does not exist.".format(self.nwb_path))
-        self.nwbfilename = [f for f in os.listdir(self.nwb_path) if "nwb" in f][0]
-        self.nwbfilepath = os.path.join(self.nwb_path, self.nwbfilename)
 
         io = NWBHDF5IO(self.nwbfilepath, "r")
         nwbfile = io.read()

--- a/pynapple/io/suite2p.py
+++ b/pynapple/io/suite2p.py
@@ -13,7 +13,7 @@ https://github.com/MouseLand/suite2p
 
 """
 
-import os
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -60,7 +60,8 @@ class Suite2P(BaseLoader):
         path : str
             The path of the session
         """
-        self.basename = os.path.basename(path)
+        path = Path(path)
+        self.basename = path.name
 
         super().__init__(path)
 
@@ -75,13 +76,6 @@ class Suite2P(BaseLoader):
         path : str
             Path to the session
         """
-        self.nwb_path = os.path.join(path, "pynapplenwb")
-        if not os.path.exists(self.nwb_path):
-            raise RuntimeError("Path {} does not exist.".format(self.nwb_path))
-
-        self.nwbfilename = [f for f in os.listdir(self.nwb_path) if "nwb" in f][0]
-        self.nwbfilepath = os.path.join(self.nwb_path, self.nwbfilename)
-
         io = NWBHDF5IO(self.nwbfilepath, "r")
         nwbfile = io.read()
 

--- a/tests/test_folder.py
+++ b/tests/test_folder.py
@@ -94,18 +94,3 @@ def test_load(path):
     folder.load()
     for k in data.keys():
         assert type(folder[k]) == type(data[k])
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/tests/test_folder.py
+++ b/tests/test_folder.py
@@ -11,25 +11,19 @@ import numpy as np
 import pandas as pd
 import pytest
 import warnings
-import os
+from pathlib import Path
+import shutil
 import json
 
 # look for tests folder
-path = os.getcwd()
-if os.path.basename(path) == 'pynapple':
-    path = os.path.join(path, "tests")
+path = Path(__file__).parent
+if path.name == 'pynapple':
+    path = path / "tests" 
+path = path / "npzfilestest"
 
-path = os.path.join(path, "npzfilestest")
-if not os.path.isdir(path):
-    os.mkdir(path)
-# path2 = os.path.join(path, "sub")
-# if not os.path.isdir(path):
-#     os.mkdir(path2)
-
-# Cleaning
-for root, dirs, files in os.walk(path):
-    for f in files:        
-        os.remove(os.path.join(root, f))
+# Recursively remove the folder:
+shutil.rmtree(path, ignore_errors=True)
+path.mkdir(exist_ok=True, parents=True)
 
 # Populate the folder
 data = {
@@ -45,9 +39,7 @@ data = {
     }
 
 for k, d in data.items():
-    d.save(os.path.join(path, k+".npz"))
-# for k, d in data.items():
-#     d.save(os.path.join(path, "sub", k+".npz"))
+    d.save(path / (k+".npz"))
 
 @pytest.mark.parametrize("path", [path])
 def test_load_folder(path):
@@ -78,11 +70,11 @@ def test_save(folder):
 
     assert isinstance(folder['tsd2'], nap.Tsd)
 
-    files = os.listdir(folder.path)
+    files = [f.name for f in path.iterdir()]
     assert "tsd2.json" in files
 
     # check json
-    metadata = json.load(open(os.path.join(path, "tsd2.json"), "r"))
+    metadata = json.load(open(path / "tsd2.json", "r"))
     assert "time" in metadata.keys()
     assert "info" in metadata.keys()
     assert "Test description" == metadata["info"]

--- a/tests/test_interval_set.py
+++ b/tests/test_interval_set.py
@@ -475,7 +475,6 @@ def test_str_():
     assert isinstance(ep.__str__(), str)
 
 def test_save_npz():
-    import os
 
     start = np.around(np.array([0, 10, 16], dtype=np.float64), 9)
     end = np.around(np.array([5, 15, 20], dtype=np.float64), 9)
@@ -494,12 +493,10 @@ def test_save_npz():
     assert str(e.value) == "Path {} does not exist.".format(Path(fake_path).resolve())
 
     ep.save("ep.npz")
-    os.listdir('.')
-    assert "ep.npz" in os.listdir(".")
+    assert "ep.npz" in [f.name for f in Path('.').iterdir()]
 
     ep.save("ep2")
-    os.listdir('.')
-    assert "ep2.npz" in os.listdir(".")
+    assert "ep2.npz" in [f.name for f in Path('.').iterdir()]
 
     file = np.load("ep.npz")
 
@@ -511,8 +508,8 @@ def test_save_npz():
     np.testing.assert_array_almost_equal(file['end'], end)
 
     # Cleaning    
-    os.remove("ep.npz")
-    os.remove("ep2.npz")    
+    Path("ep.npz").unlink()
+    Path("ep2.npz").unlink()  
 
 
 

--- a/tests/test_interval_set.py
+++ b/tests/test_interval_set.py
@@ -260,11 +260,11 @@ def test_tot_length():
 
 def test_as_units():
     ep = nap.IntervalSet(start=0, end=100)
-    df = pd.DataFrame(data=np.array([[0.0, 100.0]]), columns=["start", "end"])
-    pd.testing.assert_frame_equal(df, ep.as_units("s"))
-    pd.testing.assert_frame_equal(df * 1e3, ep.as_units("ms"))
+    df = pd.DataFrame(data=np.array([[0.0, 100.0]]), columns=["start", "end"], dtype=np.float64)
+    pd.testing.assert_frame_equal(df, ep.as_units("s").astype(np.float64))
+    pd.testing.assert_frame_equal(df * 1e3, ep.as_units("ms").astype(np.float64))
     tmp = df * 1e6
-    np.testing.assert_array_almost_equal(tmp.values, ep.as_units("us").values)
+    np.testing.assert_array_almost_equal(tmp.values, ep.as_units("us").values.astype(np.float64))
 
 
 def test_intersect():
@@ -498,14 +498,14 @@ def test_save_npz():
     ep.save("ep2")
     assert "ep2.npz" in [f.name for f in Path('.').iterdir()]
 
-    file = np.load("ep.npz")
+    with np.load("ep.npz") as file:
 
-    keys = list(file.keys())    
-    assert 'start' in keys
-    assert 'end' in keys
+        keys = list(file.keys())
+        assert 'start' in keys
+        assert 'end' in keys
 
-    np.testing.assert_array_almost_equal(file['start'], start)
-    np.testing.assert_array_almost_equal(file['end'], end)
+        np.testing.assert_array_almost_equal(file['start'], start)
+        np.testing.assert_array_almost_equal(file['end'], end)
 
     # Cleaning    
     Path("ep.npz").unlink()

--- a/tests/test_interval_set.py
+++ b/tests/test_interval_set.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 import warnings
 from .mock import MockArray
+from pathlib import Path
 
 
 def test_create_iset():
@@ -480,18 +481,17 @@ def test_save_npz():
     end = np.around(np.array([5, 15, 20], dtype=np.float64), 9)
     ep = nap.IntervalSet(start=start,end=end)
 
-    with pytest.raises(RuntimeError) as e:
+    with pytest.raises(TypeError) as e:
         ep.save(dict)
-    assert str(e.value) == "Invalid type; please provide filename as string"
 
     with pytest.raises(RuntimeError) as e:
         ep.save('./')
-    assert str(e.value) == "Invalid filename input. {} is directory.".format("./")
+    assert str(e.value) == "Invalid filename input. {} is directory.".format(Path("./").resolve())
 
     fake_path = './fake/path'
     with pytest.raises(RuntimeError) as e:
         ep.save(fake_path+'/file.npz')
-    assert str(e.value) == "Path {} does not exist.".format(fake_path)
+    assert str(e.value) == "Path {} does not exist.".format(Path(fake_path).resolve())
 
     ep.save("ep.npz")
     os.listdir('.')

--- a/tests/test_lazy_loading.py
+++ b/tests/test_lazy_loading.py
@@ -1,4 +1,3 @@
-import os.path
 import warnings
 from contextlib import nullcontext as does_not_raise
 from pathlib import Path

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -11,24 +11,27 @@ import numpy as np
 import pandas as pd
 import pytest
 import warnings
-import os
+from pathlib import Path
+import shutil
 
 # look for tests folder
-path = os.getcwd()
-if os.path.basename(path) == 'pynapple':
-    path = os.path.join(path, "tests")
+path = Path(__file__).parent
+if path.name == 'pynapple':
+    path = path / "tests" 
+path = path / "npzfilestest"
 
-path = os.path.join(path, "npzfilestest")
-if not os.path.isdir(path):
-    os.mkdir(path)
-path2 = os.path.join(path, "sub")
-if not os.path.isdir(path):
-    os.mkdir(path2)
+# Recursively remove the folder:
+shutil.rmtree(path, ignore_errors=True)
+path.mkdir(exist_ok=True, parents=True)
+
+path2 = path.parent / "sub"
+path2.mkdir(exist_ok=True, parents=True)
+
 
 @pytest.mark.parametrize("path", [path])
 def test_load_file(path):
     tsd = nap.Tsd(t=np.arange(100), d=np.arange(100))   
-    file_path = os.path.join(path, "tsd.npz")
+    file_path = path / "tsd.npz"
     tsd.save(file_path)
     tsd2 = nap.load_file(file_path)
 
@@ -37,7 +40,7 @@ def test_load_file(path):
     np.testing.assert_array_equal(tsd.values, tsd2.values)
     np.testing.assert_array_equal(tsd.time_support.values, tsd2.time_support.values)
 
-    os.remove(file_path)
+    file_path.unlink()
 
 @pytest.mark.parametrize("path", [path])
 def test_load_file_filenotfound(path):
@@ -48,13 +51,13 @@ def test_load_file_filenotfound(path):
 
 @pytest.mark.parametrize("path", [path])
 def test_load_wrong_format(path):
-    file_path = os.path.join(path, "test.npy")
+    file_path = path / "test.npy"
     np.save(file_path, np.random.rand(10))
     with pytest.raises(RuntimeError) as e:
         nap.load_file(file_path)
 
     assert str(e.value) == "File format not supported"
-    os.remove(file_path)
+    file_path.unlink()
 
 @pytest.mark.parametrize("path", [path])
 def test_load_folder(path):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -62,7 +62,7 @@ def test_load_folder(path):
     assert isinstance(folder, nap.io.Folder)
 
 def test_load_folder_foldernotfound():
-    with pytest.raises(RuntimeError) as e:
+    with pytest.raises(FileNotFoundError) as e:
         nap.load_folder("MissingFolder")
 
     assert str(e.value) == "Folder MissingFolder does not exist"

--- a/tests/test_npz_file.py
+++ b/tests/test_npz_file.py
@@ -11,24 +11,22 @@ import numpy as np
 import pandas as pd
 import pytest
 import warnings
-import os
+from pathlib import Path
+import shutil
 
 # look for tests folder
-path = os.getcwd()
-if os.path.basename(path) == 'pynapple':
-    path = os.path.join(path, "tests")
+path = Path(__file__).parent
+if path.name == 'pynapple':
+    path = path / "tests" 
+path = path / "npzfilestest"
 
-path = os.path.join(path, "npzfilestest")
-if not os.path.isdir(path):
-    os.mkdir(path)
-path2 = os.path.join(path, "sub")
-if not os.path.isdir(path):
-    os.mkdir(path2)
+# Recursively remove the folder:
+shutil.rmtree(path, ignore_errors=True)
+path.mkdir(exist_ok=True, parents=True)
 
-# Cleaning
-for root, dirs, files in os.walk(path):
-    for f in files:        
-        os.remove(os.path.join(root, f))
+path2 = path.parent / "sub"
+path2.mkdir(exist_ok=True, parents=True)
+
 
 # Populate the folder
 data = {
@@ -43,12 +41,12 @@ data = {
     "iset":nap.IntervalSet(start=np.array([0.0, 5.0]), end=np.array([1.0, 6.0]))
     }
 for k, d in data.items():
-    d.save(os.path.join(path, k+".npz"))
+    d.save(path / (k+".npz"))
 
 @pytest.mark.parametrize("path", [path])
 def test_init(path):
     tsd = nap.Tsd(t=np.arange(100), d=np.arange(100))   
-    file_path = os.path.join(path, "tsd.npz")
+    file_path = path / "tsd.npz"
     tsd.save(file_path)
     file = nap.NPZFile(file_path)
     assert isinstance(file, nap.NPZFile)
@@ -58,7 +56,7 @@ def test_init(path):
 @pytest.mark.parametrize("path", [path])
 @pytest.mark.parametrize("k", ['tsd', 'ts', 'tsdframe', 'tsgroup', 'iset'])
 def test_load(path, k):
-    file_path = os.path.join(path, k+".npz")
+    file_path = path / (k+".npz")
     file = nap.NPZFile(file_path)
     tmp = file.load()
     assert isinstance(tmp, type(data[k]))
@@ -66,7 +64,7 @@ def test_load(path, k):
 @pytest.mark.parametrize("path", [path])
 @pytest.mark.parametrize("k", ['tsgroup'])
 def test_load_tsgroup(path, k):
-    file_path = os.path.join(path, k+".npz")
+    file_path = path / (k+".npz")
     file = nap.NPZFile(file_path)
     tmp = file.load()
     assert isinstance(tmp, type(data[k]))
@@ -79,7 +77,7 @@ def test_load_tsgroup(path, k):
 @pytest.mark.parametrize("path", [path])
 @pytest.mark.parametrize("k", ['tsd'])
 def test_load_tsd(path, k):
-    file_path = os.path.join(path, k+".npz")
+    file_path = path / (k+".npz")
     file = nap.NPZFile(file_path)
     tmp = file.load()
     assert isinstance(tmp, type(data[k]))
@@ -91,7 +89,7 @@ def test_load_tsd(path, k):
 @pytest.mark.parametrize("path", [path])
 @pytest.mark.parametrize("k", ['ts'])
 def test_load_ts(path, k):
-    file_path = os.path.join(path, k+".npz")
+    file_path = path / (k+".npz")
     file = nap.NPZFile(file_path)
     tmp = file.load()
     assert isinstance(tmp, type(data[k]))
@@ -103,7 +101,7 @@ def test_load_ts(path, k):
 @pytest.mark.parametrize("path", [path])
 @pytest.mark.parametrize("k", ['tsdframe'])
 def test_load_tsdframe(path, k):
-    file_path = os.path.join(path, k+".npz")
+    file_path = path / (k+".npz")
     file = nap.NPZFile(file_path)
     tmp = file.load()
     assert isinstance(tmp, type(data[k]))
@@ -116,7 +114,7 @@ def test_load_tsdframe(path, k):
 
 @pytest.mark.parametrize("path", [path])
 def test_load_non_npz(path):
-    file_path = os.path.join(path, "random.npz")
+    file_path = path / "random.npz"
     tmp = np.random.rand(100)
     np.savez(file_path, a=tmp)
     file = nap.NPZFile(file_path)    

--- a/tests/test_nwb.py
+++ b/tests/test_nwb.py
@@ -96,7 +96,7 @@ def test_NWBFile_missing_file():
 
 
 def test_NWBFile_wrong_input():
-    with pytest.raises(RuntimeError):
+    with pytest.raises(TypeError):
         nap.NWBFile(1)
 
 def test_wrong_key():

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -1,7 +1,7 @@
 """Tests of time series for `pynapple` package."""
 
 import pickle
-
+from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
@@ -749,18 +749,17 @@ class Test_Time_Series_2:
     def test_save_npz(self, tsd):
         import os
 
-        with pytest.raises(RuntimeError) as e:
+        with pytest.raises(TypeError) as e:
             tsd.save(dict)
-        assert str(e.value) == "Invalid type; please provide filename as string"
 
         with pytest.raises(RuntimeError) as e:
             tsd.save('./')
-        assert str(e.value) == "Invalid filename input. {} is directory.".format("./")
+        assert str(e.value) == "Invalid filename input. {} is directory.".format(Path("./").resolve())
 
         fake_path = './fake/path'
         with pytest.raises(RuntimeError) as e:
             tsd.save(fake_path+'/file.npz')
-        assert str(e.value) == "Path {} does not exist.".format(fake_path)
+        assert str(e.value) == "Path {} does not exist.".format(Path(fake_path).resolve())
 
         tsd.save("tsd.npz")
         os.listdir('.')
@@ -990,18 +989,17 @@ class Test_Time_Series_3:
     def test_save_npz(self, tsdframe):
         import os
 
-        with pytest.raises(RuntimeError) as e:
+        with pytest.raises(TypeError) as e:
             tsdframe.save(dict)
-        assert str(e.value) == "Invalid type; please provide filename as string"
 
         with pytest.raises(RuntimeError) as e:
             tsdframe.save('./')
-        assert str(e.value) == "Invalid filename input. {} is directory.".format("./")
+        assert str(e.value) == "Invalid filename input. {} is directory.".format(Path("./").resolve())
 
         fake_path = './fake/path'
         with pytest.raises(RuntimeError) as e:
             tsdframe.save(fake_path+'/file.npz')
-        assert str(e.value) == "Path {} does not exist.".format(fake_path)
+        assert str(e.value) == "Path {} does not exist.".format(Path(fake_path).resolve())
 
         tsdframe.save("tsdframe.npz")
         os.listdir('.')
@@ -1113,18 +1111,17 @@ class Test_Time_Series_4:
     def test_save_npz(self, ts):
         import os
 
-        with pytest.raises(RuntimeError) as e:
+        with pytest.raises(TypeError) as e:
             ts.save(dict)
-        assert str(e.value) == "Invalid type; please provide filename as string"
 
         with pytest.raises(RuntimeError) as e:
             ts.save('./')
-        assert str(e.value) == "Invalid filename input. {} is directory.".format("./")
+        assert str(e.value) == "Invalid filename input. {} is directory.".format(Path("./").resolve())
 
         fake_path = './fake/path'
         with pytest.raises(RuntimeError) as e:
             ts.save(fake_path+'/file.npz')
-        assert str(e.value) == "Path {} does not exist.".format(fake_path)
+        assert str(e.value) == "Path {} does not exist.".format(Path(fake_path).resolve())
 
         ts.save("ts.npz")
         os.listdir('.')
@@ -1354,18 +1351,17 @@ class Test_Time_Series_5:
     def test_save_npz(self, tsdtensor):
         import os
 
-        with pytest.raises(RuntimeError) as e:
+        with pytest.raises(TypeError) as e:
             tsdtensor.save(dict)
-        assert str(e.value) == "Invalid type; please provide filename as string"
 
         with pytest.raises(RuntimeError) as e:
             tsdtensor.save('./')
-        assert str(e.value) == "Invalid filename input. {} is directory.".format("./")
+        assert str(e.value) == "Invalid filename input. {} is directory.".format(Path("./").resolve())
 
         fake_path = './fake/path'
         with pytest.raises(RuntimeError) as e:
             tsdtensor.save(fake_path+'/file.npz')
-        assert str(e.value) == "Path {} does not exist.".format(fake_path)
+        assert str(e.value) == "Path {} does not exist.".format(Path(fake_path).resolve())
 
         tsdtensor.save("tsdtensor.npz")
         os.listdir('.')

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
+from pathlib import Path
 
 import pynapple as nap
 
@@ -747,8 +748,6 @@ class Test_Time_Series_2:
             np.testing.assert_array_almost_equal(tsgroup[i].index, t[i])
         
     def test_save_npz(self, tsd):
-        import os
-
         with pytest.raises(TypeError) as e:
             tsd.save(dict)
 
@@ -762,12 +761,10 @@ class Test_Time_Series_2:
         assert str(e.value) == "Path {} does not exist.".format(Path(fake_path).resolve())
 
         tsd.save("tsd.npz")
-        os.listdir('.')
-        assert "tsd.npz" in os.listdir(".")
+        assert "tsd.npz" in [f.name for f in Path('.').iterdir()]
 
         tsd.save("tsd2")
-        os.listdir('.')
-        assert "tsd2.npz" in os.listdir(".")
+        assert "tsd2.npz" in [f.name for f in Path('.').iterdir()]
 
         file = np.load("tsd.npz")
 
@@ -782,8 +779,8 @@ class Test_Time_Series_2:
         np.testing.assert_array_almost_equal(file['start'], tsd.time_support.start)
         np.testing.assert_array_almost_equal(file['end'], tsd.time_support.end)
 
-        os.remove("tsd.npz")
-        os.remove("tsd2.npz")
+        Path("tsd.npz").unlink()
+        Path("tsd2.npz").unlink()
 
     def test_interpolate(self, tsd):
         
@@ -987,8 +984,6 @@ class Test_Time_Series_3:
         np.testing.assert_array_almost_equal(meantsd.values, tmp.loc[np.arange(1,5)].values)
 
     def test_save_npz(self, tsdframe):
-        import os
-
         with pytest.raises(TypeError) as e:
             tsdframe.save(dict)
 
@@ -1002,12 +997,10 @@ class Test_Time_Series_3:
         assert str(e.value) == "Path {} does not exist.".format(Path(fake_path).resolve())
 
         tsdframe.save("tsdframe.npz")
-        os.listdir('.')
-        assert "tsdframe.npz" in os.listdir(".")
+        assert "tsdframe.npz" in [f.name for f in Path('.').iterdir()]
 
         tsdframe.save("tsdframe2")
-        os.listdir('.')
-        assert "tsdframe2.npz" in os.listdir(".")
+        assert "tsdframe2.npz" in [f.name for f in Path('.').iterdir()]
 
         file = np.load("tsdframe.npz")
 
@@ -1024,8 +1017,8 @@ class Test_Time_Series_3:
         np.testing.assert_array_almost_equal(file['end'], tsdframe.time_support.end)
         np.testing.assert_array_almost_equal(file['columns'], tsdframe.columns)
 
-        os.remove("tsdframe.npz")
-        os.remove("tsdframe2.npz")
+        Path("tsdframe.npz").unlink()
+        Path("tsdframe2.npz").unlink()
 
     def test_interpolate(self, tsdframe):
         
@@ -1109,8 +1102,6 @@ class Test_Time_Series_4:
         assert isinstance(ts.__str__(), str)
 
     def test_save_npz(self, ts):
-        import os
-
         with pytest.raises(TypeError) as e:
             ts.save(dict)
 
@@ -1124,12 +1115,10 @@ class Test_Time_Series_4:
         assert str(e.value) == "Path {} does not exist.".format(Path(fake_path).resolve())
 
         ts.save("ts.npz")
-        os.listdir('.')
-        assert "ts.npz" in os.listdir(".")
+        assert "ts.npz" in [f.name for f in Path('.').iterdir()]
 
         ts.save("ts2")
-        os.listdir('.')
-        assert "ts2.npz" in os.listdir(".")
+        assert "ts2.npz" in [f.name for f in Path('.').iterdir()]
 
         file = np.load("ts.npz")
 
@@ -1142,8 +1131,8 @@ class Test_Time_Series_4:
         np.testing.assert_array_almost_equal(file['start'], ts.time_support.start)
         np.testing.assert_array_almost_equal(file['end'], ts.time_support.end)
 
-        os.remove("ts.npz")
-        os.remove("ts2.npz")
+        Path("ts.npz").unlink()
+        Path("ts2.npz").unlink()
 
     def test_fillna(self, ts):
         with pytest.raises(AssertionError):
@@ -1349,8 +1338,6 @@ class Test_Time_Series_5:
         np.testing.assert_array_almost_equal(meantsd.values, tmp)
 
     def test_save_npz(self, tsdtensor):
-        import os
-
         with pytest.raises(TypeError) as e:
             tsdtensor.save(dict)
 
@@ -1364,12 +1351,10 @@ class Test_Time_Series_5:
         assert str(e.value) == "Path {} does not exist.".format(Path(fake_path).resolve())
 
         tsdtensor.save("tsdtensor.npz")
-        os.listdir('.')
-        assert "tsdtensor.npz" in os.listdir(".")
+        assert "tsdtensor.npz" in [f.name for f in Path('.').iterdir()]
 
         tsdtensor.save("tsdtensor2")
-        os.listdir('.')
-        assert "tsdtensor2.npz" in os.listdir(".")
+        assert "tsdtensor2.npz" in [f.name for f in Path('.').iterdir()]
 
         file = np.load("tsdtensor.npz")
 
@@ -1384,8 +1369,8 @@ class Test_Time_Series_5:
         np.testing.assert_array_almost_equal(file['start'], tsdtensor.time_support.start)
         np.testing.assert_array_almost_equal(file['end'], tsdtensor.time_support.end)
 
-        os.remove("tsdtensor.npz")
-        os.remove("tsdtensor2.npz")
+        Path("tsdtensor.npz").unlink()
+        Path("tsdtensor2.npz").unlink()
 
     def test_interpolate(self, tsdtensor):
         

--- a/tests/test_ts_group.py
+++ b/tests/test_ts_group.py
@@ -520,8 +520,6 @@ class TestTsGroup1:
 
     def test_save_npz(self, group):
 
-        import os
-
         group = {
             0: nap.Tsd(t=np.arange(0, 20), d = np.random.rand(20)),
             1: nap.Tsd(t=np.arange(0, 20, 0.5), d=np.random.rand(40)),
@@ -543,12 +541,10 @@ class TestTsGroup1:
         assert str(e.value) == "Path {} does not exist.".format(Path(fake_path).resolve())
 
         tsgroup.save("tsgroup.npz")
-        os.listdir('.')
-        assert "tsgroup.npz" in os.listdir(".")
+        assert "tsgroup.npz" in [f.name for f in Path('.').iterdir()]
 
         tsgroup.save("tsgroup2")
-        os.listdir('.')
-        assert "tsgroup2.npz" in os.listdir(".")
+        assert "tsgroup2.npz" in [f.name for f in Path('.').iterdir()]
 
         file = np.load("tsgroup.npz")
 
@@ -589,9 +585,9 @@ class TestTsGroup1:
             assert 'd' not in list(file.keys())
             np.testing.assert_array_almost_equal(file['t'], tsgroup3[0].index)
 
-        os.remove("tsgroup.npz")
-        os.remove("tsgroup2.npz")
-        os.remove("tsgroup3.npz")
+        Path("tsgroup.npz").unlink()
+        Path("tsgroup2.npz").unlink()
+        Path("tsgroup3.npz").unlink()
 
     @pytest.mark.parametrize(
         "keys, expectation",

--- a/tests/test_ts_group.py
+++ b/tests/test_ts_group.py
@@ -14,6 +14,7 @@ from contextlib import nullcontext as does_not_raise
 import numpy as np
 import pandas as pd
 import pytest
+from pathlib import Path
 
 import pynapple as nap
 
@@ -529,18 +530,17 @@ class TestTsGroup1:
 
         tsgroup = nap.TsGroup(group, meta = np.arange(len(group), dtype=np.int64), meta2 = np.array(['a', 'b', 'c']))
 
-        with pytest.raises(RuntimeError) as e:
+        with pytest.raises(TypeError) as e:
             tsgroup.save(dict)
-        assert str(e.value) == "Invalid type; please provide filename as string"
 
         with pytest.raises(RuntimeError) as e:
             tsgroup.save('./')
-        assert str(e.value) == "Invalid filename input. {} is directory.".format("./")
+        assert str(e.value) == "Invalid filename input. {} is directory.".format(Path("./").resolve())
 
         fake_path = './fake/path'
         with pytest.raises(RuntimeError) as e:
             tsgroup.save(fake_path+'/file.npz')
-        assert str(e.value) == "Path {} does not exist.".format(fake_path)
+        assert str(e.value) == "Path {} does not exist.".format(Path(fake_path).resolve())
 
         tsgroup.save("tsgroup.npz")
         os.listdir('.')


### PR DESCRIPTION
Refactoring that purges the `os` dependency for working with the filesystem in favour of the more modern `pathlib`, as per #299.

Since I was not sure of the temporal horizon of the removal of importing modules I just did the refactoring everywhere. 

I also included a small refactoring to avoid the code duplications in the `save` methods across `Ts`X classes.