### PR TITLE
Fixing nan bug when creating bins from min and max of feature

### DIFF
--- a/pynapple/process/tuning_curves.py
+++ b/pynapple/process/tuning_curves.py
@@ -119,7 +119,7 @@ def compute_1d_tuning_curves(group, feature, nb_bins, ep=None, minmax=None):
         assert isinstance(ep, nap.IntervalSet), "ep should be an IntervalSet"
 
     if minmax is None:
-        bins = np.linspace(np.min(feature), np.max(feature), nb_bins + 1)
+        bins = np.linspace(np.nanmin(feature), np.nanmax(feature), nb_bins + 1)
     else:
         assert isinstance(minmax, tuple), "minmax should be a tuple of boundaries"
         bins = np.linspace(minmax[0], minmax[1], nb_bins + 1)
@@ -275,7 +275,7 @@ def compute_1d_mutual_info(tc, feature, ep=None, minmax=None, bitssec=False):
 
     nb_bins = tc.shape[0] + 1
     if minmax is None:
-        bins = np.linspace(np.min(feature), np.max(feature), nb_bins)
+        bins = np.linspace(np.nanmin(feature), np.nanmax(feature), nb_bins)
     else:
         bins = np.linspace(minmax[0], minmax[1], nb_bins)
 
@@ -445,7 +445,7 @@ def compute_1d_tuning_curves_continuous(
         tsdframe = tsdframe.restrict(feature.time_support)
 
     if minmax is None:
-        bins = np.linspace(np.min(feature), np.max(feature), nb_bins + 1)
+        bins = np.linspace(np.nanmin(feature), np.nanmax(feature), nb_bins + 1)
     else:
         bins = np.linspace(minmax[0], minmax[1], nb_bins + 1)
 


### PR DESCRIPTION
Hello! 
I noticed that in functions such as `compute_1d_mutual_info()` (along with others), when the `minmax` argument is not provided, the bins are made using the minimum and maximum value of the provided feature using functions `np.min()` and `np.max()`. The issue with this, however, is that if there are any nans in the feature, then `np.min()` and `np.max()` will return nan; This results in bins of 'nans', and therefore mutual info values of all zeros. I've had a similar issue with tuning curves. To fix this, I changed the the `np.min()` and `np.max()` functions to `np.nanmin()` and `np.nanmax()` respectively. These functions ignore nans.