### PR TITLE
Refactor tuning curves

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,9 +12,7 @@ PYthon Neural Analysis Package.
 pynapple is a light-weight python library for neurophysiological data analysis. The goal is to offer a versatile set of tools to study typical data in the field, i.e. time series (spike times, behavioral events, etc.) and time intervals (trials, brain states, etc.). It also provides users with generic functions for neuroscience such as tuning curves and cross-correlograms.
 
 -   Free software: MIT License
--   __Documentation__: <https://pynapple-org.github.io/pynapple>
--   __Notebooks and tutorials__ : <https://pynapple-org.github.io/pynapple/generated/gallery/>
-<!-- -   __Collaborative repository__: <https://github.com/PeyracheLab/pynacollada> -->
+-   __Documentation__: <https://pynapple.org>
 
 
 > **Note**

--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -139,7 +139,7 @@ class BaseTsd(Base, NDArrayOperatorsMixin, abc.ABC):
         return self.values.size
 
     def __array__(self, dtype=None):
-        return self.values.astype(dtype)
+        return np.asarray(self.values, dtype=dtype)
 
     def __array_ufunc__(self, ufunc, method, *args, **kwargs):
         # print("In __array_ufunc__")

--- a/pynapple/process/tuning_curves.py
+++ b/pynapple/process/tuning_curves.py
@@ -35,7 +35,7 @@ def _validate_tuning_inputs(func):
                 raise TypeError(
                     "features should be a TsdFrame with 2 columns"
                 )
-            if isinstance(kwargs["features"], nap.TsdFrame) and not kwargs["features"].shape[1] == 2:
+            if not kwargs["features"].shape[1] == 2:
                 raise ValueError(
                     "features should have 2 columns only."
                 )
@@ -221,7 +221,7 @@ def compute_2d_tuning_curves(group, features, nb_bins, ep=None, minmax=None):
     minmax : tuple or list, optional
         The min and max boundaries of the tuning curves given as:
         (minx, maxx, miny, maxy)
-        If None, the boundaries are inferred from the target variable
+        If None, the boundaries are inferred from the target features
 
     Returns
     -------
@@ -242,22 +242,20 @@ def compute_2d_tuning_curves(group, features, nb_bins, ep=None, minmax=None):
         )
     if ep is None:
         ep = features.time_support
-    else:
-        features = features.restrict(ep)
 
     cols = list(features.columns)
     groups_value = {}
     binsxy = {}
 
-    for i, c in enumerate(cols):
-        groups_value[c] = group.value_from(features.loc[c], ep)
+    for i in range(2):
+        groups_value[cols[i]] = group.value_from(features[:,i], ep)
         if minmax is None:
             bins = np.linspace(
-                np.min(features.loc[c]), np.max(features.loc[c]), nb_bins + 1
+                np.nanmin(features[:,i]), np.nanmax(features[:,i]), nb_bins + 1
             )
         else:
             bins = np.linspace(minmax[i + i % 2], minmax[i + 1 + i % 2], nb_bins + 1)
-        binsxy[c] = bins
+        binsxy[cols[i]] = bins
 
     occupancy, _, _ = np.histogram2d(
         features.loc[cols[0]].values.flatten(),
@@ -392,7 +390,7 @@ def compute_2d_mutual_info(dict_tc, features, ep=None, minmax=None, bitssec=Fals
         if minmax is None:
             bins.append(
                 np.linspace(
-                    np.min(features.loc[c]), np.max(features.loc[c]), nb_bins[i]
+                    np.nanmin(features.loc[c]), np.nanmax(features.loc[c]), nb_bins[i]
                 )
             )
         else:
@@ -552,7 +550,7 @@ def compute_2d_tuning_curves_continuous(
     for i, c in enumerate(cols):
         if minmax is None:
             bins = np.linspace(
-                np.min(features.loc[c]), np.max(features.loc[c]), nb_bins[i] + 1
+                np.nanmin(features.loc[c]), np.nanmax(features.loc[c]), nb_bins[i] + 1
             )
         else:
             bins = np.linspace(minmax[i + i % 2], minmax[i + 1 + i % 2], nb_bins[i] + 1)

--- a/pynapple/process/tuning_curves.py
+++ b/pynapple/process/tuning_curves.py
@@ -1,7 +1,16 @@
 # -*- coding: utf-8 -*-
 """
-FUnctions for computing tuning curves :
+You can compute tuning curves for features in 1 dimension or 2 dimension.
 
+| Function | Description |
+|------|------|
+| `nap.compute_discrete_tuning_curves` | Firing rate from a dictionnary of IntervalSet|
+| `compute_1d_tuning_curves` | Firing rate as a function of a 1-d feature |
+| `compute_2d_tuning_curves` | Firing rate as a function of a 2-d features |
+| `compute_1d_tuning_curves_continuous` | Mean value as a function of a 1-d feature |
+| `compute_2d_tuning_curves_continuous` | Mean value as a function of a 2-d features |
+| `compute_1d_mutual_info` | Mutual information of a tuning curve computed from a 1-d feature. |
+| `compute_2d_mutual_info` | Mutual information of a tuning curve computed from a 2-d features. |
 
 """
 

--- a/pynapple/process/tuning_curves.py
+++ b/pynapple/process/tuning_curves.py
@@ -242,6 +242,8 @@ def compute_2d_tuning_curves(group, features, nb_bins, ep=None, minmax=None):
         )
     if ep is None:
         ep = features.time_support
+    else:
+        features = features.restrict(ep)
 
     cols = list(features.columns)
     groups_value = {}

--- a/tests/test_tuning_curves.py
+++ b/tests/test_tuning_curves.py
@@ -71,7 +71,7 @@ def test_compute_1d_mutual_info_errors(tc, feature, ep, minmax, bitssec, expecte
         nap.compute_1d_mutual_info(tc, feature, ep, minmax, bitssec)
 
 @pytest.mark.parametrize("dict_tc, features, ep, minmax, bitssec, expected_exception", [
-    ("a", get_features(), get_ep(), (0, 1), True, "Argument dict_tc should be a dictionary of numpy.ndarray"),
+    ("a", get_features(), get_ep(), (0, 1), True, "Argument dict_tc should be a dictionary of numpy.ndarray or numpy.ndarray"),
     ({0:np.zeros((2,2))},"a", get_ep(), (0, 1), True, r"features should be a TsdFrame with 2 columns"),
     ({0:np.zeros((2,2))}, get_features(), "a", (0, 1), True, r"ep should be an IntervalSet"),
     ({0:np.zeros((2,2))}, get_features(), get_ep(), 1, True, r"minmax should be a tuple\/list of 2 numbers"),
@@ -108,9 +108,13 @@ def test_compute_2d_tuning_curves_continuous_errors(tsdframe, features, nb_bins,
 ########################
 @pytest.mark.parametrize("func, args, minmax, expected", [
     (nap.compute_1d_tuning_curves, (get_group(), get_feature(), 10), (0,1,2), "minmax should be of length 2."),
+    (nap.compute_1d_tuning_curves_continuous, (get_tsdframe(), get_feature(), 10), (0,1,2), "minmax should be of length 2."),
     (nap.compute_2d_tuning_curves, (get_group(), get_features(), 10), (0,1,2), "minmax should be of length 4."),
+    (nap.compute_2d_tuning_curves_continuous, (get_tsdframe(), get_features(), 10), (0,1,2), "minmax should be of length 4."),
     (nap.compute_2d_tuning_curves, (get_group(), nap.TsdFrame(t=np.arange(10),d=np.ones((10,3))), 10), (0,1), "features should have 2 columns only."),
     (nap.compute_1d_tuning_curves, (get_group(), nap.TsdFrame(t=np.arange(10),d=np.ones((10,3))), 10), (0,1), r"feature should be a Tsd \(or TsdFrame with 1 column only\)"),
+    (nap.compute_2d_tuning_curves, (get_group(), get_features(), (0, 1, 2)), (0,1,2,3), r"nb_bins should be of type int \(or tuple with \(int, int\) for 2D tuning curves\)."),
+    (nap.compute_2d_tuning_curves_continuous, (get_tsdframe(), get_features(), (0, 1, 2)), (0,1,2,3), r"nb_bins should be of type int \(or tuple with \(int, int\) for 2D tuning curves\)."),
 ])
 def test_compute_tuning_curves_value_error(func, args, minmax, expected):
     with pytest.raises(ValueError, match=expected):
@@ -161,6 +165,7 @@ def test_compute_1d_tuning_curves(args, kwargs, expected):
 @pytest.mark.filterwarnings("ignore")
 @pytest.mark.parametrize("args, kwargs, expected", [
     ((get_group(), get_features(), 10), {}, np.ones((10,10))*0.5),
+    ((get_group(), get_features(), (10,10)), {}, np.ones((10,10))*0.5),
     ((get_group(), get_features(), 10), {"ep":nap.IntervalSet(0, 400)}, np.ones((10,10))*0.25),
     ((get_group(), get_features(), 10), {"minmax":(0, 100, 0, 100)}, np.ones((10,10))*0.5),
     ((get_group(), get_features(), 10), {"minmax":(0, 200, 0, 100)}, np.vstack((np.ones((5,10))*0.5,np.ones((5,10))*np.nan))),
@@ -175,198 +180,153 @@ def test_compute_2d_tuning_curves(args, kwargs, expected):
     # Index
     assert isinstance(xy, list)
     assert len(xy) == 2
+    nb_bins = args[2]
+    if isinstance(args[2], int):
+        nb_bins = (args[2], args[2])
     if "minmax" in kwargs:
-        tmp1 = np.linspace(kwargs["minmax"][0], kwargs["minmax"][1], args[2] + 1)
-        tmp2 = np.linspace(kwargs["minmax"][2], kwargs["minmax"][3], args[2] + 1)
+        tmp1 = np.linspace(kwargs["minmax"][0], kwargs["minmax"][1], nb_bins[0] + 1)
+        tmp2 = np.linspace(kwargs["minmax"][2], kwargs["minmax"][3], nb_bins[1] + 1)
     else:
-        tmp1 = np.linspace(np.min(args[1][:,0]), np.max(args[1][:,0]), args[2] + 1)
-        tmp2 = np.linspace(np.min(args[1][:,1]), np.max(args[1][:,1]), args[2] + 1)
+        tmp1 = np.linspace(np.min(args[1][:,0]), np.max(args[1][:,0]), nb_bins[0] + 1)
+        tmp2 = np.linspace(np.min(args[1][:,1]), np.max(args[1][:,1]), nb_bins[1] + 1)
 
     np.testing.assert_almost_equal(tmp1[0:-1] + np.diff(tmp1)/2, xy[0])
     np.testing.assert_almost_equal(tmp2[0:-1] + np.diff(tmp2)/2, xy[1])
 
     # Values
     for i in tc.keys():
-        assert tc[i].shape == (args[2], args[2])
+        assert tc[i].shape == nb_bins
         np.testing.assert_almost_equal(tc[i], expected)
 
 
-
-
-
-
-
-def test_compute_1d_mutual_info():
-    tc = pd.DataFrame(index=np.arange(0, 2), data=np.array([0, 10]))
-    feature = nap.Tsd(t=np.arange(100), d=np.tile(np.arange(2), 50))
-    si = nap.compute_1d_mutual_info(tc, feature)
+@pytest.mark.filterwarnings("ignore")
+@pytest.mark.parametrize("args, kwargs, expected", [
+    ((pd.DataFrame(index=np.arange(0, 2), data=np.array([0, 10])),
+      nap.Tsd(t=np.arange(100), d=np.tile(np.arange(2), 50)),),
+     {}, np.array([[1.]])),
+    ((pd.DataFrame(index=np.arange(0, 2), data=np.array([0, 10])),
+      nap.Tsd(t=np.arange(100), d=np.tile(np.arange(2), 50)),),
+     {"bitssec":True}, np.array([[5.]])),
+    ((pd.DataFrame(index=np.arange(0, 2), data=np.array([0, 10])),
+      nap.Tsd(t=np.arange(100), d=np.tile(np.arange(2), 50)),),
+     {"ep": nap.IntervalSet(start=0, end=49)}, np.array([[1.]])),
+    ((pd.DataFrame(index=np.arange(0, 2), data=np.array([0, 10])),
+      nap.Tsd(t=np.arange(100), d=np.tile(np.arange(2), 50)),),
+     {"minmax": (0, 1)}, np.array([[1.]])),
+    ((np.array([[0],[10]]),
+      nap.Tsd(t=np.arange(100), d=np.tile(np.arange(2), 50)),),
+     {"minmax": (0, 1)}, np.array([[1.]])),
+])
+def test_compute_1d_mutual_info(args, kwargs, expected):
+    tc = args[0]
+    feature = args[1]
+    si = nap.compute_1d_mutual_info(tc, feature, **kwargs)
     assert isinstance(si, pd.DataFrame)
     assert list(si.columns) == ["SI"]
-    assert list(si.index.values) == list(tc.columns)
-    np.testing.assert_approx_equal(si.loc[0, "SI"], 1.0)
-    si = nap.compute_1d_mutual_info(tc, feature, bitssec=True)
-    np.testing.assert_approx_equal(si.loc[0, "SI"], 5.0)
-
-    ep = nap.IntervalSet(start=0, end=49)
-    si = nap.compute_1d_mutual_info(tc, feature, ep=ep)
-    np.testing.assert_approx_equal(si.loc[0, "SI"], 1.0)
-    si = nap.compute_1d_mutual_info(tc, feature, ep=ep, bitssec=True)
-    np.testing.assert_approx_equal(si.loc[0, "SI"], 5.0)
-
-    minmax = (0, 1)
-    si = nap.compute_1d_mutual_info(tc, feature, minmax=minmax)
-    np.testing.assert_approx_equal(si.loc[0, "SI"], 1.0)
-
-def test_compute_1d_mutual_info_array():    
-    tc = np.array([[0],[10]])
-    feature = nap.Tsd(t=np.arange(100), d=np.tile(np.arange(2), 50))
-    si = nap.compute_1d_mutual_info(tc, feature)
-    assert isinstance(si, pd.DataFrame)
-    assert list(si.columns) == ["SI"]    
-    np.testing.assert_approx_equal(si.loc[0, "SI"], 1.0)
-    si = nap.compute_1d_mutual_info(tc, feature, bitssec=True)
-    np.testing.assert_approx_equal(si.loc[0, "SI"], 5.0)
-
-def test_compute_2d_mutual_info():
-    dict_tc = {0: np.array([[0, 1], [0, 0]])}
-    features = nap.TsdFrame(
-        t=np.arange(100), d=np.tile(np.array([[0, 0, 1, 1], [0, 1, 0, 1]]), 25).T
-    )
-    si = nap.compute_2d_mutual_info(dict_tc, features)
-    assert isinstance(si, pd.DataFrame)
-    assert list(si.columns) == ["SI"]
-    assert list(si.index.values) == list(dict_tc.keys())
-    np.testing.assert_approx_equal(si.loc[0, "SI"], 2.0)
-    si = nap.compute_2d_mutual_info(dict_tc, features, bitssec=True)
-    np.testing.assert_approx_equal(si.loc[0, "SI"], 0.5)
-
-    ep = nap.IntervalSet(start=0, end=7)
-    si = nap.compute_2d_mutual_info(dict_tc, features, ep=ep)
-    np.testing.assert_approx_equal(si.loc[0, "SI"], 2.0)
-    si = nap.compute_2d_mutual_info(dict_tc, features, ep=ep, bitssec=True)
-    np.testing.assert_approx_equal(si.loc[0, "SI"], 0.5)
-
-    minmax = (0, 1, 0, 1)
-    si = nap.compute_2d_mutual_info(dict_tc, features, minmax=minmax)
-    np.testing.assert_approx_equal(si.loc[0, "SI"], 2.0)
-
-
-@pytest.mark.parametrize(
-    "tsd, expected_columns",
-    [
-        (nap.TsdFrame(t=np.arange(0, 100), d=np.ones((100, 1))), [0]),
-        (nap.TsdFrame(t=np.arange(0, 100), d=np.ones((100, 2))), [0, 1]),
-        (nap.Tsd(t=np.arange(0, 100), d=np.ones((100, ))), [0])
-    ]
-)
-def test_compute_1d_tuning_curves_continuous(tsd, expected_columns):
-    feature = nap.Tsd(t=np.arange(0, 100, 0.1), d=np.arange(0, 100, 0.1) % 1.0)
-    tc = nap.compute_1d_tuning_curves_continuous(tsd, feature, nb_bins=10)
-
-    assert len(tc) == 10
-    assert list(tc.columns) == expected_columns
-    np.testing.assert_array_almost_equal(tc[0].values[1:], np.zeros(9))
-    assert int(tc[0].values[0]) == 1.0
-
-
-def test_compute_1d_tuning_curves_continuous_with_ep():
-    tsdframe = nap.TsdFrame(t=np.arange(0, 100), d=np.ones((100, 1)))
-    feature = nap.Tsd(t=np.arange(0, 100, 0.1), d=np.arange(0, 100, 0.1) % 1.0)
-    ep = nap.IntervalSet(start=0, end=50)
-    tc1 = nap.compute_1d_tuning_curves_continuous(tsdframe, feature, nb_bins=10)
-    tc2 = nap.compute_1d_tuning_curves_continuous(tsdframe, feature, nb_bins=10, ep=ep)
-    pd.testing.assert_frame_equal(tc1, tc2)
-
-
-def test_compute_1d_tuning_curves_continuous_with_min_max():
-    tsdframe = nap.TsdFrame(t=np.arange(0, 100), d=np.ones((100, 1)))
-    feature = nap.Tsd(t=np.arange(0, 100, 0.1), d=np.arange(0, 100, 0.1) % 1.0)
-    tc = nap.compute_1d_tuning_curves_continuous(
-        tsdframe, feature, nb_bins=10, minmax=(0, 1)
-    )
-    assert len(tc) == 10
-    np.testing.assert_array_almost_equal(tc[0].values[1:], np.zeros(9))
-    assert tc[0].values[0] == 1.0
-
-@pytest.mark.parametrize(
-    "tsdframe, expected_columns",
-    [
-        (nap.TsdFrame(t=np.arange(0, 100), d=np.hstack((np.ones((100, 1)), np.ones((100, 1)) * 2))), [0, 1]),
-        (
-                nap.TsdFrame(t=np.arange(0, 100), d=np.hstack((np.ones((100, 1)), np.ones((100, 1)) * 2)),
-                             columns=["x", "y"]),
-                ["x", "y"]
-        ),
-        (nap.Tsd(t=np.arange(0, 100), d=np.hstack((np.ones((100, )) * 2))), [0])
-
-    ]
-)
-@pytest.mark.parametrize("nb_bins", [1, 2, 3])
-def test_compute_2d_tuning_curves_continuous(nb_bins, tsdframe, expected_columns):
-
-    features = nap.TsdFrame(
-        t=np.arange(100), d=np.tile(np.array([[0, 0, 1, 1], [0, 1, 0, 1]]), 25).T
-    )
-    tc, xy = nap.compute_2d_tuning_curves_continuous(tsdframe, features, nb_bins)
-
-    assert isinstance(tc, dict)
-    assert list(tc.keys()) == expected_columns
-    for i in tc.keys():
-        assert tc[i].shape == (nb_bins, nb_bins)
-
-    assert isinstance(xy, list)
-    assert len(xy) == 2
-    for i in range(2):
-        assert np.min(xy) > 0
-        assert np.max(xy) < 1
-
-
-def test_compute_2d_tuning_curves_continuous_output_value():
-    tsdframe = nap.TsdFrame(t=np.arange(0, 100), d=np.hstack((np.ones((100, 1)), np.ones((100, 1)) * 2)))
-    features = nap.TsdFrame(
-        t=np.arange(100), d=np.tile(np.array([[0, 0, 1, 1], [0, 1, 0, 1]]), 25).T
-    )
-    tc, xy = nap.compute_2d_tuning_curves_continuous(tsdframe, features, 2)
-    tmp = np.zeros((2, 2, 2))
-    tmp[:, 0, 0] = [1, 2]
-    for i in range(2):
-        np.testing.assert_array_almost_equal(tc[i], tmp[i])
-
-
-def test_compute_2d_tuning_curves_continuous_with_ep():
-    tsdframe = nap.TsdFrame(
-        t=np.arange(0, 100), d=np.hstack((np.ones((100, 1)), np.ones((100, 1)) * 2))
-    )
-    features = nap.TsdFrame(
-        t=np.arange(100), d=np.tile(np.array([[0, 0, 1, 1], [0, 1, 0, 1]]), 25).T
-    )
-    ep = nap.IntervalSet(start=0, end=7)
-    tc1, xy = nap.compute_2d_tuning_curves_continuous(tsdframe, features, 2, ep=ep)
-    tc2, xy = nap.compute_2d_tuning_curves_continuous(tsdframe, features, 2)
-
-    for i in tc1.keys():
-        np.testing.assert_array_almost_equal(tc1[i], tc2[i])
-
-
-
-
+    if isinstance(tc, pd.DataFrame):
+        assert list(si.index.values) == list(tc.columns)
+    np.testing.assert_approx_equal(si.values, expected)
 
 
 @pytest.mark.filterwarnings("ignore")
-def test_compute_2d_tuning_curves_with_minmax():
-    tsdframe = nap.TsdFrame(
-        t=np.arange(0, 100), d=np.hstack((np.ones((100, 1)), np.ones((100, 1)) * 2))
-    )
+@pytest.mark.parametrize("args, kwargs, expected", [
+    (({0: np.array([[0, 1], [0, 0]])},
+        nap.TsdFrame(t=np.arange(100), d=np.tile(np.array([[0, 0, 1, 1], [0, 1, 0, 1]]), 25).T)
+      ), {}, np.array([[2.0]]) ),
+    ((np.array([[[0, 1], [0, 0]]]),
+      nap.TsdFrame(t=np.arange(100), d=np.tile(np.array([[0, 0, 1, 1], [0, 1, 0, 1]]), 25).T)
+      ), {}, np.array([[2.0]])),
+    (({0: np.array([[0, 1], [0, 0]])},
+      nap.TsdFrame(t=np.arange(100), d=np.tile(np.array([[0, 0, 1, 1], [0, 1, 0, 1]]), 25).T)
+      ), {"bitssec":True}, np.array([[0.5]])),
+    (({0: np.array([[0, 1], [0, 0]])},
+      nap.TsdFrame(t=np.arange(100), d=np.tile(np.array([[0, 0, 1, 1], [0, 1, 0, 1]]), 25).T)
+      ), {"ep": nap.IntervalSet(start=0, end=7)}, np.array([[2.0]])),
+    (({0: np.array([[0, 1], [0, 0]])},
+      nap.TsdFrame(t=np.arange(100), d=np.tile(np.array([[0, 0, 1, 1], [0, 1, 0, 1]]), 25).T)
+      ), {"minmax": (0,1,0,1)}, np.array([[2.0]])),
+])
+def test_compute_2d_mutual_info(args, kwargs, expected):
+    dict_tc = args[0]
+    features = args[1]
+    si = nap.compute_2d_mutual_info(dict_tc, features, **kwargs)
+    assert isinstance(si, pd.DataFrame)
+    assert list(si.columns) == ["SI"]
+    if isinstance(dict_tc, dict):
+        assert list(si.index.values) == list(dict_tc.keys())
+    np.testing.assert_approx_equal(si.values, expected)
+
+
+@pytest.mark.filterwarnings("ignore")
+@pytest.mark.parametrize("args, kwargs, expected", [
+    ((get_tsdframe(), get_feature(), 10), {}, np.vstack((np.ones((1,2)), np.zeros((9,2))))),
+    ((get_tsdframe(), get_feature()[:,np.newaxis], 10), {}, np.vstack((np.ones((1,2)), np.zeros((9,2))))),
+    ((get_tsdframe()[:,0], get_feature(), 10), {}, np.vstack((np.ones((1,1)), np.zeros((9,1))))),
+    ((get_tsdframe(), get_feature(), 10), {"ep":get_ep()}, np.vstack((np.ones((1,2)), np.zeros((9,2))))),
+    ((get_tsdframe(), get_feature(), 10), {"minmax":(0, 0.9)}, np.vstack((np.ones((1,2)), np.zeros((9,2))))),
+    ((get_tsdframe(), get_feature(), 20), {"minmax":(0, 1.9)}, np.vstack((np.ones((1,2)), np.zeros((9,2)), np.ones((10,2))*np.nan))),
+])
+def test_compute_1d_tuning_curves_continuous(args, kwargs, expected):
+    tsdframe, feature, nb_bins = args
+    tc = nap.compute_1d_tuning_curves_continuous(tsdframe, feature, nb_bins, **kwargs)
+    # Columns
+    if hasattr(tsdframe, "columns"):
+        assert list(tc.columns) == list(tsdframe.columns)
+    # Index
+    assert len(tc) == nb_bins
+    if "minmax" in kwargs:
+        tmp = np.linspace(kwargs["minmax"][0], kwargs["minmax"][1], nb_bins + 1)
+    else:
+        tmp = np.linspace(np.min(args[1]), np.max(args[1]), nb_bins + 1)
+    np.testing.assert_almost_equal(tmp[0:-1] + np.diff(tmp)/2, tc.index.values)
+    # Array
+    np.testing.assert_almost_equal(tc.values, expected)
+
+
+
+@pytest.mark.parametrize("tsdframe, nb_bins, kwargs, expected", [
+    (nap.TsdFrame(t=np.arange(0, 100), d=np.hstack((np.ones((100, 1)), np.ones((100, 1)) * 2))),
+        1, {}, {0: np.array([[1.]]), 1: np.array([[2.]])}),
+    (nap.TsdFrame(t=np.arange(0, 100), d=np.hstack((np.ones((100, 1)), np.ones((100, 1)) * 2)), columns=["x", "y"]),
+        2, {}, {'x': np.array([[1,0],[0,0]]), 'y': np.array([[2,0],[0,0]])}),
+    (nap.Tsd(t=np.arange(0, 100), d=np.hstack((np.ones((100, )) * 2))),
+     2, {}, {0: np.array([[2, 0], [0, 0]])}),
+    (nap.TsdFrame(t=np.arange(0, 100), d=np.hstack((np.ones((100, 1)), np.ones((100, 1)) * 2))),
+        (1,2), {}, {0: np.array([[1., 0.0]]), 1: np.array([[2., 0.0]])}),
+    (nap.TsdFrame(t=np.arange(0, 100), d=np.hstack((np.ones((100, 1)), np.ones((100, 1)) * 2))),
+     1, {"ep":get_ep()}, {0: np.array([[1.]]), 1: np.array([[2.]])}),
+    (nap.TsdFrame(t=np.arange(0, 100), d=np.hstack((np.ones((100, 1)), np.ones((100, 1)) * 2))),
+     1, {"minmax": (0, 1, 0, 1)}, {0: np.array([[1.]]), 1: np.array([[2.]])}),
+    (nap.TsdFrame(t=np.arange(0, 100), d=np.hstack((np.ones((100, 1)), np.ones((100, 1)) * 2))),
+     (1, 3), {"minmax": (0, 1, 0, 3)}, {0: np.array([[1., 1., np.nan]]), 1: np.array([[2., 2., np.nan]])}),
+])
+def test_compute_2d_tuning_curves_continuous(tsdframe, nb_bins, kwargs, expected):
     features = nap.TsdFrame(
         t=np.arange(100), d=np.tile(np.array([[0, 0, 1, 1], [0, 1, 0, 1]]), 25).T
     )
-    minmax = (0, 10, 0, 2)
-    tc, xy = nap.compute_2d_tuning_curves_continuous(
-        tsdframe, features, 2, minmax=minmax
-    )
+    tc, xy = nap.compute_2d_tuning_curves_continuous(tsdframe, features, nb_bins, **kwargs)
 
+    # Keys
+    if hasattr(tsdframe, "columns"):
+        assert list(tc.keys()) == list(tsdframe.columns)
+
+    # Index
+    assert isinstance(xy, list)
     assert len(xy) == 2
-    xbins = np.linspace(minmax[0], minmax[1], 3)
-    np.testing.assert_array_almost_equal(xy[0], xbins[0:-1] + np.diff(xbins) / 2)
-    ybins = np.linspace(minmax[2], minmax[3], 3)
-    np.testing.assert_array_almost_equal(xy[1], ybins[0:-1] + np.diff(ybins) / 2)
+    if isinstance(nb_bins, int):
+        nb_bins = (nb_bins, nb_bins)
+    if "minmax" in kwargs:
+        tmp1 = np.linspace(kwargs["minmax"][0], kwargs["minmax"][1], nb_bins[0] + 1)
+        tmp2 = np.linspace(kwargs["minmax"][2], kwargs["minmax"][3], nb_bins[1] + 1)
+    else:
+        tmp1 = np.linspace(np.min(features[:,0]), np.max(features[:,0]), nb_bins[0] + 1)
+        tmp2 = np.linspace(np.min(features[:,1]), np.max(features[:,1]), nb_bins[1] + 1)
+
+    np.testing.assert_almost_equal(tmp1[0:-1] + np.diff(tmp1)/2, xy[0])
+    np.testing.assert_almost_equal(tmp2[0:-1] + np.diff(tmp2)/2, xy[1])
+
+    # Values
+    for i in tc.keys():
+        assert tc[i].shape == nb_bins
+        np.testing.assert_almost_equal(tc[i], expected[i])
+

--- a/tests/test_tuning_curves.py
+++ b/tests/test_tuning_curves.py
@@ -109,6 +109,8 @@ def test_compute_2d_tuning_curves_continuous_errors(tsdframe, features, nb_bins,
 @pytest.mark.parametrize("func, args, minmax, expected", [
     (nap.compute_1d_tuning_curves, (get_group(), get_feature(), 10), (0,1,2), "minmax should be of length 2."),
     (nap.compute_2d_tuning_curves, (get_group(), get_features(), 10), (0,1,2), "minmax should be of length 4."),
+    (nap.compute_2d_tuning_curves, (get_group(), nap.TsdFrame(t=np.arange(10),d=np.ones((10,3))), 10), (0,1), "features should have 2 columns only."),
+    (nap.compute_1d_tuning_curves, (get_group(), nap.TsdFrame(t=np.arange(10),d=np.ones((10,3))), 10), (0,1), r"feature should be a Tsd \(or TsdFrame with 1 column only\)"),
 ])
 def test_compute_tuning_curves_value_error(func, args, minmax, expected):
     with pytest.raises(ValueError, match=expected):
@@ -187,6 +189,9 @@ def test_compute_2d_tuning_curves(args, kwargs, expected):
     for i in tc.keys():
         assert tc[i].shape == (args[2], args[2])
         np.testing.assert_almost_equal(tc[i], expected)
+
+
+
 
 
 


### PR DESCRIPTION
- Fix issue #334.
- Adding `nanmin` and `nanmax` (with help from #330)
- Adding validation method as a decorator for all tuning curves methods. Check type of every arguments collectively.
- Refactor tests for module `tuning_curves.py`.