### PR TITLE
nwb interface: allow full paths in __getitem__

### DIFF
--- a/docs/api_guide/tutorial_pynapple_core.py
+++ b/docs/api_guide/tutorial_pynapple_core.py
@@ -70,7 +70,7 @@ print(tsdframe)
 # Interval Sets object
 # --------------------
 #
-# The [IntervalSet](https://pynapple-org.github.io/pynapple/reference/core/interval_set/) object stores multiple epochs with a common time unit. It can then be used to restrict time series to this particular set of epochs.
+# The [IntervalSet](../../../reference/core/interval_set/) object stores multiple epochs with a common time unit. It can then be used to restrict time series to this particular set of epochs.
 
 
 epochs = nap.IntervalSet(start=[0, 10], end=[5, 15], time_units="s")
@@ -82,7 +82,7 @@ print("\n")
 print(new_tsd)
 
 # %%
-# Multiple operations are available for IntervalSet. For example, IntervalSet can be merged. See the full documentation of the class [here](https://pynapple-org.github.io/pynapple/reference/core/interval_set/#pynapple.core.interval_set.IntervalSet.intersect) for a list of all the functions that can be used to manipulate IntervalSets.
+# Multiple operations are available for IntervalSet. For example, IntervalSet can be merged. See the full documentation of the class [here](../../../reference/core/interval_set/#pynapple.core.interval_set.IntervalSet.intersect) for a list of all the functions that can be used to manipulate IntervalSets.
 
 
 epoch1 = nap.IntervalSet(start=0, end=10)  # no time units passed. Default is us.
@@ -132,7 +132,7 @@ count = tsgroup.count(
 print(count)
 
 # %%
-# One advantage of grouping time series is that metainformation can be added directly on an element-wise basis. In this case, we add labels to each Ts object when instantiating the group and after. We can then use this label to split the group. See the [TsGroup](https://pynapple-org.github.io/pynapple/reference/core/ts_group/) documentation for a complete methodology for splitting TsGroup objects.
+# One advantage of grouping time series is that metainformation can be added directly on an element-wise basis. In this case, we add labels to each Ts object when instantiating the group and after. We can then use this label to split the group. See the [TsGroup](../../../reference/core/ts_group/) documentation for a complete methodology for splitting TsGroup objects.
 #
 # First we create a pandas Series for the label.
 

--- a/docs/api_guide/tutorial_pynapple_quick_start.py
+++ b/docs/api_guide/tutorial_pynapple_quick_start.py
@@ -7,15 +7,15 @@ The data contains a sample recordings taken simultaneously from the anterodorsal
 
 Preprocessing of the data was made with [Kilosort 2.0](https://github.com/MouseLand/Kilosort) and spike sorting was made with [Klusters](https://neurosuite.sourceforge.net/).
 
-Instructions for installing pynapple can be found [here](https://pynapple-org.github.io/pynapple/#installation).
+Instructions for installing pynapple can be found [here](../../../installation).
 
 ***
 
 This notebook is meant to provide an overview of pynapple by going through:
 
-- **Input output (IO)**. In this case, pynapple will load a NWB file using the [NWBFile object](https://pynapple-org.github.io/pynapple/reference/io/interface_nwb/#pynapple.io.interface_nwb.NWBFile) within a project [Folder](https://pynapple-org.github.io/pynapple/reference/io/folder/) that represent a dataset.
-- **Core functions** that handle time series, interval sets and groups of time series. See this [notebook](https://pynapple-org.github.io/pynapple/generated/api_guide/tutorial_pynapple_core/) for a detailled usage of the core functions.
-- **Process functions**. A small collection of high-level functions widely used in system neuroscience. This [notebook](https://pynapple-org.github.io/pynapple/generated/api_guide/tutorial_pynapple_process) details those functions.
+- **Input output (IO)**. In this case, pynapple will load a NWB file using the [NWBFile object](../../../reference/io/interface_nwb/#pynapple.io.interface_nwb.NWBFile) within a project [Folder](../../../reference/io/folder/) that represent a dataset.
+- **Core functions** that handle time series, interval sets and groups of time series. See this [notebook](../../api_guide/tutorial_pynapple_core/) for a detailled usage of the core functions.
+- **Process functions**. A small collection of high-level functions widely used in system neuroscience. This [notebook](../../api_guide/tutorial_pynapple_process) details those functions.
 
 """
 
@@ -63,13 +63,13 @@ DATA_DIRECTORY = "MyProject/"
 
 
 # %%
-# We can load the session with the function [load_folder](https://pynapple-org.github.io/pynapple/reference/io/misc/#pynapple.io.misc.load_folder). Pynapple will walks throught the folder and collects every subfolders.
+# We can load the session with the function [load_folder](../../../reference/io/misc/#pynapple.io.misc.load_folder). Pynapple will walks throught the folder and collects every subfolders.
 # We can use the attribute `view` or the function `expand` to display a tree view of the dataset. The treeview shows all the compatible data format (i.e npz files or NWBs files) and their equivalent pynapple type.
 data = nap.load_folder(DATA_DIRECTORY)
 data.view
 
 # %%
-# The object `data` is a [`Folder`](https://pynapple-org.github.io/pynapple/reference/io/folder/) object that allows easy navigation and interaction with a dataset.
+# The object `data` is a [`Folder`](../../../reference/io/folder/) object that allows easy navigation and interaction with a dataset.
 # In this case, we want to load the NWB file in the folder `/pynapplenwb`. Data are always lazy loaded. No time series is loaded until it's actually called.
 # When calling the NWB file, the object `nwb` is an interface to the NWB file. All the data inside the NWB file that are compatible with one of the pynapple objects are shown with their corresponding keys.
 nwb = data["sub-A2929"]["A2929-200711"]["pynapplenwb"]["A2929-200711"]
@@ -79,7 +79,7 @@ print(nwb)
 # %%
 # We can individually call each object and they are actually loaded.
 #
-# `units` is a [TsGroup](https://pynapple-org.github.io/pynapple/reference/core/ts_group/) object. It allows to group together time series with different timestamps and couple metainformation to each neuron. In this case, the location of where the neuron was recorded has been added when loading the session for the first time.
+# `units` is a [TsGroup](../../../reference/core/ts_group/) object. It allows to group together time series with different timestamps and couple metainformation to each neuron. In this case, the location of where the neuron was recorded has been added when loading the session for the first time.
 # We load `units` as `spikes`
 spikes = nwb["units"]
 print(spikes)
@@ -90,7 +90,7 @@ neuron_0 = spikes[0]
 print(neuron_0)
 
 # %%
-# `neuron_0` is a [Ts](https://pynapple-org.github.io/pynapple/reference/core/time_series/#pynapple.core.time_series.Ts) object containing the times of the spikes.
+# `neuron_0` is a [Ts](../../../reference/core/time_series/#pynapple.core.time_series.Ts) object containing the times of the spikes.
 
 # %%
 # The other information about the session is contained in `nwb["epochs"]`. In this case, the start and end of the sleep and wake epochs. If the NWB time intervals contains tags of the epochs, pynapple will try to group them together and return a dictionary of IntervalSet instead of IntervalSet.
@@ -147,7 +147,7 @@ print(epochs_above_thr)
 # ***
 # Tuning curves
 # -------------
-# Let's do a more advanced analysis. Neurons from ADn (group 0 in the `spikes` group object) are know to fire for a particular direction. Therefore, we can compute their tuning curves, i.e. their firing rates as a function of the head-direction of the animal in the horizontal plane (*ry*). To do this, we can use the function [`compute_1d_tuning_curves`](https://pynapple-org.github.io/pynapple/reference/process/tuning_curves/#pynapple.process.tuning_curves.compute_1d_tuning_curves). In this case, the tuning curves are computed over 120 bins and between 0 and 2$\pi$.
+# Let's do a more advanced analysis. Neurons from ADn (group 0 in the `spikes` group object) are know to fire for a particular direction. Therefore, we can compute their tuning curves, i.e. their firing rates as a function of the head-direction of the animal in the horizontal plane (*ry*). To do this, we can use the function [`compute_1d_tuning_curves`](../../../reference/process/tuning_curves/#pynapple.process.tuning_curves.compute_1d_tuning_curves). In this case, the tuning curves are computed over 120 bins and between 0 and 2$\pi$.
 
 tuning_curves = nap.compute_1d_tuning_curves(
     group=spikes, feature=head_direction, nb_bins=121, minmax=(0, 2 * np.pi)
@@ -170,7 +170,7 @@ plt.tight_layout()
 plt.show()
 
 # %%
-# While ADN neurons show obvious modulation for head-direction, it is not obvious for all CA1 cells. Therefore we want to restrict the remaining of the analyses to only ADN neurons. We can split the `spikes` group with the function [`getby_category`](https://pynapple-org.github.io/pynapple/reference/core/ts_group/#pynapple.core.ts_group.TsGroup.getby_category).
+# While ADN neurons show obvious modulation for head-direction, it is not obvious for all CA1 cells. Therefore we want to restrict the remaining of the analyses to only ADN neurons. We can split the `spikes` group with the function [`getby_category`](../../../reference/core/ts_group/#pynapple.core.ts_group.TsGroup.getby_category).
 
 spikes_by_location = spikes.getby_category("location")
 
@@ -186,7 +186,7 @@ spikes_adn = spikes_by_location["adn"]
 # ------------
 # A classical question with head-direction cells is how pairs stay coordinated across brain states i.e. wake vs sleep (see Peyrache, A., Lacroix, M. M., Petersen, P. C., & Buzsáki, G. (2015). Internally organized mechanisms of the head direction sense. Nature neuroscience, 18(4), 569-575.)
 #
-# In this example, this coordination across brain states will be evaluated with cross-correlograms of pairs of neurons. We can call the function [`compute_crosscorrelogram`](https://pynapple-org.github.io/pynapple/reference/process/correlograms/#pynapple.process.correlograms.compute_crosscorrelogram) during both sleep and wake epochs.
+# In this example, this coordination across brain states will be evaluated with cross-correlograms of pairs of neurons. We can call the function [`compute_crosscorrelogram`](../../../reference/process/correlograms/#pynapple.process.correlograms.compute_crosscorrelogram) during both sleep and wake epochs.
 
 cc_wake = nap.compute_crosscorrelogram(
     group=spikes_adn,
@@ -240,7 +240,7 @@ plt.show()
 # This last analysis shows how to use the pynapple's decoding function.
 #
 # The previous result indicates a persistent coordination of head-direction cells during sleep. Therefore it is possible to decode a virtual head-direction signal even if the animal is not moving its head.
-# This example uses the function [`decode_1d`](https://pynapple-org.github.io/pynapple/reference/process/decoding/#pynapple.process.decoding.decode_1d) which implements bayesian decoding (see : Zhang, K., Ginzburg, I., McNaughton, B. L., & Sejnowski, T. J. (1998). Interpreting neuronal population activity by reconstruction: unified framework with application to hippocampal place cells. Journal of neurophysiology, 79(2), 1017-1044.)
+# This example uses the function [`decode_1d`](../../../reference/process/decoding/#pynapple.process.decoding.decode_1d) which implements bayesian decoding (see : Zhang, K., Ginzburg, I., McNaughton, B. L., & Sejnowski, T. J. (1998). Interpreting neuronal population activity by reconstruction: unified framework with application to hippocampal place cells. Journal of neurophysiology, 79(2), 1017-1044.)
 #
 # First we can validate the decoding function with the real position of the head of the animal during wake.
 
@@ -285,7 +285,7 @@ decoded_sleep, proba_angle_Sleep = nap.decode_1d(
 )
 
 # %%
-# Here we are gonna chain the TsGroup function [`set_info`](https://pynapple-org.github.io/pynapple/reference/core/ts_group/#pynapple.core.ts_group.TsGroup.set_info) and the function [`to_tsd`](https://pynapple-org.github.io/pynapple/reference/core/ts_group/#pynapple.core.ts_group.TsGroup.to_tsd) to flatten the TsGroup and quickly assign to each spikes a corresponding value found in the metadata table. Any columns of the metadata table can be assigned to timestamps in a TsGroup.
+# Here we are gonna chain the TsGroup function [`set_info`](../../../reference/core/ts_group/#pynapple.core.ts_group.TsGroup.set_info) and the function [`to_tsd`](../../../reference/core/ts_group/#pynapple.core.ts_group.TsGroup.to_tsd) to flatten the TsGroup and quickly assign to each spikes a corresponding value found in the metadata table. Any columns of the metadata table can be assigned to timestamps in a TsGroup.
 #
 # Here the value assign to the spikes comes from the preferred firing direction of the neurons. The following line is a quick way to sort the neurons based on their preferred firing direction
 order = np.argsort(np.argmax(tuning_curves_adn.values, 0))

--- a/docs/api_guide/tutorial_pynapple_spectrum.py
+++ b/docs/api_guide/tutorial_pynapple_spectrum.py
@@ -3,7 +3,7 @@
 Power spectral density
 ======================
 
-See the [documentation](https://pynapple-org.github.io/pynapple/) of Pynapple for instructions on installing the package.
+See the [documentation](/) of Pynapple for instructions on installing the package.
 
 """
 

--- a/docs/api_guide/tutorial_pynapple_wavelets.py
+++ b/docs/api_guide/tutorial_pynapple_wavelets.py
@@ -10,7 +10,7 @@ and develop over time, wavelet decompositions can aid both visualization and ana
 
 The function `nap.generate_morlet_filterbank` can help parametrize and visualize the Morlet wavelets.
 
-See the [documentation](https://pynapple-org.github.io/pynapple/) of Pynapple for instructions on installing the package.
+See the [documentation](/) of Pynapple for instructions on installing the package.
 
 This tutorial was made by [Kipp Freud](https://kippfreud.com/).
 

--- a/docs/examples/tutorial_HD_dataset.py
+++ b/docs/examples/tutorial_HD_dataset.py
@@ -7,7 +7,7 @@ This tutorial demonstrates how we use Pynapple to generate Figure 4a in the [pub
 The NWB file for the example is hosted on [OSF](https://osf.io/jb2gd). We show below how to stream it.
 The entire dataset can be downloaded [here](https://dandiarchive.org/dandiset/000056).
 
-See the [documentation](https://pynapple-org.github.io/pynapple/) of Pynapple for instructions on installing the package.
+See the [documentation](/) of Pynapple for instructions on installing the package.
 
 This tutorial was made by Dhruv Mehrotra and Guillaume Viejo.
 

--- a/docs/examples/tutorial_calcium_imaging.py
+++ b/docs/examples/tutorial_calcium_imaging.py
@@ -9,7 +9,7 @@ For the example dataset, we will be working with a recording of a freely-moving 
 
 The NWB file for the example is hosted on [OSF](https://osf.io/sbnaw). We show below how to stream it.
 
-See the [documentation](https://pynapple-org.github.io/pynapple/) of Pynapple for instructions on installing the package.
+See the [documentation](../../../) of Pynapple for instructions on installing the package.
 
 This tutorial was made by Sofia Skromne Carrasco and Guillaume Viejo.
 

--- a/docs/examples/tutorial_human_dataset.py
+++ b/docs/examples/tutorial_human_dataset.py
@@ -8,7 +8,7 @@ This tutorial demonstrates how we use Pynapple on various publicly available dat
 
 The NWB file for the example used here is provided in [this](https://github.com/PeyracheLab/pynacollada/tree/main/pynacollada/Pynapple%20Paper%20Figures/Zheng%202022/000207/sub-4) repository. The entire dataset can be downloaded [here](https://dandiarchive.org/dandiset/000207/0.220216.0323).
 
-See the [documentation](https://pynapple-org.github.io/pynapple/) of Pynapple for instructions on installing the package.
+See the [documentation](/) of Pynapple for instructions on installing the package.
 
 This tutorial was made by Dhruv Mehrotra.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ pynapple is a light-weight python library for neurophysiological data analysis. 
 
     Learn the pynapple API with notebooks.
 
-    [:octicons-arrow-right-24: API guide](https://pynapple.org/generated/api_guide/)
+    [:octicons-arrow-right-24: API guide](generated/api_guide/)
 
 -   :material-brain:{ .lg .middle} &nbsp;  __Neural Analysis__
 
@@ -52,7 +52,7 @@ pynapple is a light-weight python library for neurophysiological data analysis. 
 
     Explore fully worked examples to learn how to analyze neural recordings using pynapple.
     
-    [:octicons-arrow-right-24: Tutorials](https://pynapple.org/generated/examples/)
+    [:octicons-arrow-right-24: Tutorials](generated/examples/)
 
 -   :material-cog:{ .lg .middle } &nbsp; __API__
 
@@ -60,7 +60,7 @@ pynapple is a light-weight python library for neurophysiological data analysis. 
 
     Access a detailed description of each module and function, including parameters and functionality. 
 
-    [:octicons-arrow-right-24: Modules](https://pynapple.org/reference/)
+    [:octicons-arrow-right-24: Modules](reference/)
 
 -   :material-hammer-wrench:{ .lg .middle } &nbsp; __Installation Instructions__ 
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,11 +13,11 @@ Pynapple now implements signal processing. For example, to filter a 1250 Hz samp
 ```python
 nap.apply_bandpass_filter(signal, (10, 20), fs=1250)
 ```
-New functions includes power spectral density and Morlet wavelet decomposition. See the [documentation](https://pynapple-org.github.io/pynapple/reference/process/) for more details.
+New functions includes power spectral density and Morlet wavelet decomposition. See the [documentation](/reference/process/) for more details.
 
 ### pynapple >= 0.6
 
-Starting with 0.6, [`IntervalSet`](https://pynapple-org.github.io/pynapple/reference/core/interval_set/) objects are behaving as immutable numpy ndarray. Before 0.6, you could select an interval within an `IntervalSet` object with:
+Starting with 0.6, [`IntervalSet`](/reference/core/interval_set/) objects are behaving as immutable numpy ndarray. Before 0.6, you could select an interval within an `IntervalSet` object with:
 
 ```python
 new_intervalset = intervalset.loc[[0]] # Selecting first interval
@@ -35,7 +35,7 @@ Starting with 0.4, pynapple rely on the [numpy array container](https://numpy.or
 
 This allows for a better handling of returned objects.
 
-Additionaly, it is now possible to define time series objects with more than 2 dimensions with `TsdTensor`. You can also look at this [notebook](https://pynapple-org.github.io/pynapple/generated/api_guide/tutorial_pynapple_numpy/) for a demonstration of numpy compatibilities.
+Additionaly, it is now possible to define time series objects with more than 2 dimensions with `TsdTensor`. You can also look at this [notebook](/generated/api_guide/tutorial_pynapple_numpy/) for a demonstration of numpy compatibilities.
 
 
 Basic Usage

--- a/pynapple/core/ts_group.py
+++ b/pynapple/core/ts_group.py
@@ -187,6 +187,9 @@ class TsGroup(UserDict):
     Base functions
     """
 
+    def __dir__(self):
+        return sorted(list(super().__dir__()) + list(self._metadata.columns))
+
     def __getattr__(self, name):
         """
         Allows dynamic access to metadata columns as properties.

--- a/pynapple/io/interface_nwb.py
+++ b/pynapple/io/interface_nwb.py
@@ -73,6 +73,29 @@ def _extract_compatible_data_from_nwbfile(nwbfile):
     return data
 
 
+def _path_for_nwb_object(obj):
+    """Helper function to get the path of an NWB object"""
+    if obj.parent:
+        if obj.parent.name == 'root':
+            # unfortunately, there's now way to get the parent name when the
+            # parent is a top-level NWB object because the parent actually
+            # points to root, so we need to do it this way
+            modules = {
+                'acquisition': obj.parent.acquisition,
+                'analysis': obj.parent.analysis,
+                'stimulus': obj.parent.stimulus,
+                'processing': obj.parent.processing,
+            }
+            for k, v in modules.items():
+                if obj.name in v.keys() and v[obj.name] == obj:
+                    return f'{k}/{obj.name}'
+            return obj.name
+        else:
+            return f'{_path_for_nwb_object(obj.parent)}/{obj.name}'
+    else:
+        return obj.name
+
+
 def _make_interval_set(obj, **kwargs):
     """Helper function to make IntervalSet
 
@@ -458,9 +481,26 @@ class NWBFile(UserDict):
             If key is not in the dictionary
         """
         if key.__hash__:
+            if '/' in key:
+                # allow user to specify the full path to the object
+                # store the original key so we can verify it later
+                original_key = key
+                if original_key.startswith('/'):
+                    # remove leading slash
+                    original_key = original_key[1:]
+                # use just the last part of the key
+                key = key.split('/')[-1]
+            else:
+                original_key = None
             if self.__contains__(key):
                 if isinstance(self.data[key], dict) and "id" in self.data[key]:
-                    obj = self.nwb.objects[self.data[key]["id"]]
+                    obj_id = self.data[key]["id"]
+                    obj = self.nwb.objects[obj_id]
+                    if original_key is not None:
+                        if _path_for_nwb_object(obj) != original_key:
+                            raise KeyError(
+                                f"Mismatch between key and object path: {original_key} != {_path_for_nwb_object(obj)}"
+                            )
                     try:
                         data = self._f_eval[self.data[key]["type"]](
                             obj, lazy_loading=self._lazy_loading

--- a/pynapple/io/interface_nwb.py
+++ b/pynapple/io/interface_nwb.py
@@ -76,22 +76,22 @@ def _extract_compatible_data_from_nwbfile(nwbfile):
 def _path_for_nwb_object(obj):
     """Helper function to get the path of an NWB object"""
     if obj.parent:
-        if obj.parent.name == 'root':
+        if obj.parent.name == "root":
             # unfortunately, there's now way to get the parent name when the
             # parent is a top-level NWB object because the parent actually
             # points to root, so we need to do it this way
             modules = {
-                'acquisition': obj.parent.acquisition,
-                'analysis': obj.parent.analysis,
-                'stimulus': obj.parent.stimulus,
-                'processing': obj.parent.processing,
+                "acquisition": obj.parent.acquisition,
+                "analysis": obj.parent.analysis,
+                "stimulus": obj.parent.stimulus,
+                "processing": obj.parent.processing,
             }
             for k, v in modules.items():
                 if obj.name in v.keys() and v[obj.name] == obj:
-                    return f'{k}/{obj.name}'
+                    return f"{k}/{obj.name}"
             return obj.name
         else:
-            return f'{_path_for_nwb_object(obj.parent)}/{obj.name}'
+            return f"{_path_for_nwb_object(obj.parent)}/{obj.name}"
     else:
         return obj.name
 
@@ -481,15 +481,15 @@ class NWBFile(UserDict):
             If key is not in the dictionary
         """
         if key.__hash__:
-            if '/' in key:
+            if "/" in key:
                 # allow user to specify the full path to the object
                 # store the original key so we can verify it later
                 original_key = key
-                if original_key.startswith('/'):
+                if original_key.startswith("/"):
                     # remove leading slash
                     original_key = original_key[1:]
                 # use just the last part of the key
-                key = key.split('/')[-1]
+                key = key.split("/")[-1]
             else:
                 original_key = None
             if self.__contains__(key):


### PR DESCRIPTION
I would like to be able to reference NWB items by their full paths.

For example [in this NWB file](https://neurosift.app/?p=/nwb&url=https://api.dandiarchive.org/api/assets/5e9e92e1-f044-4aa0-ab47-1cfcb8899348/download/&dandisetId=000003&dandisetVersion=0.230629.1955)

There is acquisition/position_sensor0 and acquisition/position_sensor1

In existing package, I can do `nwbp['position_sensor0']` but I cannot do `nwbp['acquisition/position_sensor0']`

This PR modifies the NWB interface to allow both.

Why do I want this?

I am creating an AI assistant built into neurosift, and I am teaching it to load NWB into pynapple objects. Even if I tell it to not use the full path of the objects, it often tries to do that anyway. I think it reflects that using full paths is a natural thing to do.

I also think it is important to allow more than one units tables in the same NWB file. Right now, everything gets mapped to the "units" key. But I think that can be a separate PR/issue.

If you are interested in trying out the assistant, open the above neurosift link, click on the chat icon in the upper right and prompt something like

"Load the position sensors using pynapple, including showing how to load this NWB file"

(relevant to a discussion I was having with @bendichter)