### PR TITLE
Bugfix on TsdFrame getitem

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           directory: "./doc/_build/html"
           # The directory to scan
-          arguments: --checks Links,Scripts --ignore-urls "https://fonts.gstatic.com,https://mkdocs-gallery.github.io,./doc/_build/html/_static/" --assume-extension --check-external-hash --ignore-status-codes 403 --ignore-files "/.+\/html\/_static\/.+/"
+          arguments: --checks Links,Scripts --ignore-urls "https://fonts.gstatic.com,https://mkdocs-gallery.github.io,./doc/_build/html/_static/,https://www.nature.com/articles/s41593-022-01020-w" --assume-extension --check-external-hash --ignore-status-codes 403 --ignore-files "/.+\/html\/_static\/.+/"
           # The arguments to pass to HTMLProofer
 
 

--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -1172,7 +1172,11 @@ class TsdFrame(_BaseTsd, _MetadataMixin):
                 if (
                     (len(index) == 1)
                     and (output.ndim == 1)
-                    and ((len(output) > 1) or isinstance(key, int) or isinstance(key[1], (list, np.ndarray)))
+                    and (
+                        (len(output) > 1)
+                        or isinstance(key, int)
+                        or isinstance(key[1], (list, np.ndarray))
+                    )
                 ):
                     # reshape output of single index to preserve column axis if there are more than one columns being indexed
                     # or if column key is a list or array

--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -1169,26 +1169,23 @@ class TsdFrame(_BaseTsd, _MetadataMixin):
                 index = np.array([index])
 
             if all(is_array_like(a) for a in [index, output]):
-                if (
-                    (len(index) == 1)
-                    and (output.ndim == 1)
-                    and (
-                        (len(output) > 1)
-                        or isinstance(key, (int, slice))
-                        or isinstance(key[1], (list, np.ndarray))
-                    )
-                ):
-                    # reshape output of single index to preserve column axis if there are more than one columns being indexed
-                    # or if column key is a list or array
+                if isinstance(key, tuple):
+                    if (
+                        len(index) == 1
+                        and output.ndim == 1
+                        and not isinstance(key[1], int)
+                    ):
+                        output = output[None, :]
+                    elif (
+                        (output.ndim == 1)
+                        and isinstance(key[1], (list, np.ndarray))
+                        and (len(columns) == 1)
+                    ):
+                        # reshape output of single column if column key is a list or array
+                        output = output[:, None]
+                # if getting a row (1 dim implied)
+                elif isinstance(key, Number):
                     output = output[None, :]
-
-                elif (
-                    (output.ndim == 1)
-                    and isinstance(key[1], (list, np.ndarray))
-                    and (len(columns) == 1)
-                ):
-                    # reshape output of single column if column key is a list or array
-                    output = output[:, None]
 
                 kwargs["columns"] = columns
                 kwargs["metadata"] = self._metadata.loc[columns]

--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -1174,7 +1174,7 @@ class TsdFrame(_BaseTsd, _MetadataMixin):
                     and (output.ndim == 1)
                     and (
                         (len(output) > 1)
-                        or isinstance(key, int)
+                        or isinstance(key, (int, slice))
                         or isinstance(key[1], (list, np.ndarray))
                     )
                 ):

--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -1172,7 +1172,7 @@ class TsdFrame(_BaseTsd, _MetadataMixin):
                 if (
                     (len(index) == 1)
                     and (output.ndim == 1)
-                    and ((len(output) > 1) or isinstance(key[1], (list, np.ndarray)))
+                    and ((len(output) > 1) or isinstance(key, int) or isinstance(key[1], (list, np.ndarray)))
                 ):
                     # reshape output of single index to preserve column axis if there are more than one columns being indexed
                     # or if column key is a list or array

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -1051,10 +1051,10 @@ class TestTsdFrame:
         "row",
         [
             0,
-            # [0, 2],
-            # slice(20, 30),
-            # np.hstack([np.zeros(10, bool), True, True, True, np.zeros(87, bool)]),
-            # np.hstack([np.zeros(10, bool), True, np.zeros(89, bool)]),
+            [0, 2],
+            slice(20, 30),
+            np.hstack([np.zeros(10, bool), True, True, True, np.zeros(87, bool)]),
+            np.hstack([np.zeros(10, bool), True, np.zeros(89, bool)]),
         ],
     )
     @pytest.mark.parametrize(
@@ -1072,9 +1072,6 @@ class TestTsdFrame:
         if tsdframe.shape[1] == 1:
             if isinstance(col, list) and isinstance(col[0], int):
                 col = [0]
-            elif isinstance(col, slice):
-                col = slice(0, 1)
-                expected = nap.Tsd
             elif isinstance(col, list) and isinstance(col[0], bool):
                 col = [col[0]]
 

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -998,6 +998,7 @@ class TestTsdFrame:
         ],
     )
     def test_horizontal_slicing(self, tsdframe, index, nap_type):
+        index = index if isinstance(index, int) else index[: tsdframe.shape[1]]
         assert isinstance(tsdframe[:, index], nap_type)
         np.testing.assert_array_almost_equal(
             tsdframe[:, index].values, tsdframe.values[:, index]
@@ -1050,10 +1051,10 @@ class TestTsdFrame:
         "row",
         [
             0,
-            [0, 2],
-            slice(20, 30),
-            np.hstack([np.zeros(10, bool), True, True, True, np.zeros(87, bool)]),
-            np.hstack([np.zeros(10, bool), True, np.zeros(89, bool)]),
+            # [0, 2],
+            # slice(20, 30),
+            # np.hstack([np.zeros(10, bool), True, True, True, np.zeros(87, bool)]),
+            # np.hstack([np.zeros(10, bool), True, np.zeros(89, bool)]),
         ],
     )
     @pytest.mark.parametrize(
@@ -1068,6 +1069,15 @@ class TestTsdFrame:
         ],
     )
     def test_vert_and_horz_slicing(self, tsdframe, row, col, expected):
+        if tsdframe.shape[1] == 1:
+            if isinstance(col, list) and isinstance(col[0], int):
+                col = [0]
+            elif isinstance(col, slice):
+                col = slice(0, 1)
+                expected = nap.Tsd
+            elif isinstance(col, list) and isinstance(col[0], bool):
+                col = [col[0]]
+
         # get details about row index
         row_array = isinstance(row, (list, np.ndarray))
         if row_array and isinstance(row[0], (bool, np.bool_)):

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -954,6 +954,7 @@ class TestTsd:
 @pytest.mark.parametrize(
     "tsdframe",
     [
+        nap.TsdFrame(t=np.arange(100), d=np.random.rand(100, 1), time_units="s"),
         nap.TsdFrame(t=np.arange(100), d=np.random.rand(100, 3), time_units="s"),
         nap.TsdFrame(
             t=np.arange(100),


### PR DESCRIPTION
On TsdFrame of 1 column, this would cause an error:

```python
tsdframe = nap.TsdFrame(t=np.arange(10), d=np.ones((10, 1)))
tsdframe[0]
```

Since in the getitem it was checking if `key[1]` is list or array but key is an integer in this case. 

Fixed it quickly and added a test for this 1 column tsdframe.