### PR TITLE
Hotfix - tsd initialization

### DIFF
--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -477,7 +477,9 @@ class _BaseTsd(_Base, NDArrayOperatorsMixin, abc.ABC):
 
         new_data_array = _convolve(time_array, data_array, starts, ends, array, trim)
 
-        return _initialize_tsd_output(self, new_data_array, time_index=time_array, time_support=ep)
+        return _initialize_tsd_output(
+            self, new_data_array, time_index=time_array, time_support=ep
+        )
 
     def smooth(self, std, windowsize=None, time_units="s", size_factor=100, norm=True):
         """Smooth a time series with a gaussian kernel.

--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -382,7 +382,7 @@ class _BaseTsd(_Base, NDArrayOperatorsMixin, abc.ABC):
 
         t, d = _bin_average(time_array, data_array, starts, ends, bin_size)
 
-        return _initialize_tsd_output(self, d, time_index=t)
+        return _initialize_tsd_output(self, d, time_index=t, time_support=ep)
 
     def dropna(self, update_time_support=True):
         """Drop every row containing NaNs. By default, the time support is updated to start and end around the time points that are non NaNs.
@@ -477,7 +477,7 @@ class _BaseTsd(_Base, NDArrayOperatorsMixin, abc.ABC):
 
         new_data_array = _convolve(time_array, data_array, starts, ends, array, trim)
 
-        return _initialize_tsd_output(self, new_data_array, time_index=time_array)
+        return _initialize_tsd_output(self, new_data_array, time_index=time_array, time_support=ep)
 
     def smooth(self, std, windowsize=None, time_units="s", size_factor=100, norm=True):
         """Smooth a time series with a gaussian kernel.
@@ -634,7 +634,7 @@ class _BaseTsd(_Base, NDArrayOperatorsMixin, abc.ABC):
 
             start += len(t)
 
-        return _initialize_tsd_output(self, new_d, time_index=new_t)
+        return _initialize_tsd_output(self, new_d, time_index=new_t, time_support=ep)
 
 
 class TsdTensor(_BaseTsd):

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -651,7 +651,7 @@ class TestTimeSeriesGeneral:
 class TestTsd:
 
     def test_bin_average_time_support(self, tsd):
-        ep = nap.IntervalSet(tsd.time_support.start[0]+1, tsd.time_support.end[0]-1)
+        ep = nap.IntervalSet(tsd.time_support.start[0] + 1, tsd.time_support.end[0] - 1)
         out = tsd.bin_average(0.1, ep=ep)
         assert np.all(out.time_support == ep)
 
@@ -997,17 +997,23 @@ class TestTsd:
 class TestTsdFrame:
 
     def test_bin_average_time_support(self, tsdframe):
-        ep = nap.IntervalSet(tsdframe.time_support.start[0] + 1, tsdframe.time_support.end[0] - 1)
+        ep = nap.IntervalSet(
+            tsdframe.time_support.start[0] + 1, tsdframe.time_support.end[0] - 1
+        )
         out = tsdframe.bin_average(0.1, ep=ep)
         assert np.all(out.time_support == ep)
 
     def test_convolve_time_support(self, tsdframe):
-        ep = nap.IntervalSet(tsdframe.time_support.start[0] + 1, tsdframe.time_support.end[0] - 1)
+        ep = nap.IntervalSet(
+            tsdframe.time_support.start[0] + 1, tsdframe.time_support.end[0] - 1
+        )
         out = tsdframe.convolve(np.ones(10), ep=ep)
         assert np.all(out.time_support == ep)
 
     def test_interpolate_time_support(self, tsdframe):
-        ep = nap.IntervalSet(tsdframe.time_support.start[0] + 1, tsdframe.time_support.end[0] - 1)
+        ep = nap.IntervalSet(
+            tsdframe.time_support.start[0] + 1, tsdframe.time_support.end[0] - 1
+        )
         ts = nap.Ts(np.linspace(0, 10, 20))
         out = tsdframe.interpolate(ts, ep=ep)
         assert np.all(out.time_support == ep)
@@ -1624,17 +1630,23 @@ class TestTs:
 class TestTsdTensor:
 
     def test_bin_average_time_support(self, tsdtensor):
-        ep = nap.IntervalSet(tsdtensor.time_support.start[0]+1, tsdtensor.time_support.end[0]-1)
+        ep = nap.IntervalSet(
+            tsdtensor.time_support.start[0] + 1, tsdtensor.time_support.end[0] - 1
+        )
         out = tsdtensor.bin_average(0.1, ep=ep)
         assert np.all(out.time_support == ep)
 
     def test_convolve_time_support(self, tsdtensor):
-        ep = nap.IntervalSet(tsdtensor.time_support.start[0] + 1, tsdtensor.time_support.end[0] - 1)
+        ep = nap.IntervalSet(
+            tsdtensor.time_support.start[0] + 1, tsdtensor.time_support.end[0] - 1
+        )
         out = tsdtensor.convolve(np.ones(10), ep=ep)
         assert np.all(out.time_support == ep)
 
     def test_interpolate_time_support(self, tsdtensor):
-        ep = nap.IntervalSet(tsdtensor.time_support.start[0] + 1, tsdtensor.time_support.end[0] - 1)
+        ep = nap.IntervalSet(
+            tsdtensor.time_support.start[0] + 1, tsdtensor.time_support.end[0] - 1
+        )
         ts = nap.Ts(np.linspace(0, 10, 20))
         out = tsdtensor.interpolate(ts, ep=ep)
         assert np.all(out.time_support == ep)

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -649,6 +649,23 @@ class TestTimeSeriesGeneral:
     ],
 )
 class TestTsd:
+
+    def test_bin_average_time_support(self, tsd):
+        ep = nap.IntervalSet(tsd.time_support.start[0]+1, tsd.time_support.end[0]-1)
+        out = tsd.bin_average(0.1, ep=ep)
+        assert np.all(out.time_support == ep)
+
+    def test_convolve_time_support(self, tsd):
+        ep = nap.IntervalSet(tsd.time_support.start[0] + 1, tsd.time_support.end[0] - 1)
+        out = tsd.convolve(np.ones(10), ep=ep)
+        assert np.all(out.time_support == ep)
+
+    def test_interpolate_time_support(self, tsd):
+        ep = nap.IntervalSet(tsd.time_support.start[0] + 1, tsd.time_support.end[0] - 1)
+        ts = nap.Ts(np.linspace(0, 10, 20))
+        out = tsd.interpolate(ts, ep=ep)
+        assert np.all(out.time_support == ep)
+
     def test_as_series(self, tsd):
         assert isinstance(tsd.as_series(), pd.Series)
 
@@ -978,6 +995,23 @@ class TestTsd:
     ],
 )
 class TestTsdFrame:
+
+    def test_bin_average_time_support(self, tsdframe):
+        ep = nap.IntervalSet(tsdframe.time_support.start[0] + 1, tsdframe.time_support.end[0] - 1)
+        out = tsdframe.bin_average(0.1, ep=ep)
+        assert np.all(out.time_support == ep)
+
+    def test_convolve_time_support(self, tsdframe):
+        ep = nap.IntervalSet(tsdframe.time_support.start[0] + 1, tsdframe.time_support.end[0] - 1)
+        out = tsdframe.convolve(np.ones(10), ep=ep)
+        assert np.all(out.time_support == ep)
+
+    def test_interpolate_time_support(self, tsdframe):
+        ep = nap.IntervalSet(tsdframe.time_support.start[0] + 1, tsdframe.time_support.end[0] - 1)
+        ts = nap.Ts(np.linspace(0, 10, 20))
+        out = tsdframe.interpolate(ts, ep=ep)
+        assert np.all(out.time_support == ep)
+
     def test_as_dataframe(self, tsdframe):
         assert isinstance(tsdframe.as_dataframe(), pd.DataFrame)
 
@@ -1588,6 +1622,22 @@ class TestTs:
     ],
 )
 class TestTsdTensor:
+
+    def test_bin_average_time_support(self, tsdtensor):
+        ep = nap.IntervalSet(tsdtensor.time_support.start[0]+1, tsdtensor.time_support.end[0]-1)
+        out = tsdtensor.bin_average(0.1, ep=ep)
+        assert np.all(out.time_support == ep)
+
+    def test_convolve_time_support(self, tsdtensor):
+        ep = nap.IntervalSet(tsdtensor.time_support.start[0] + 1, tsdtensor.time_support.end[0] - 1)
+        out = tsdtensor.convolve(np.ones(10), ep=ep)
+        assert np.all(out.time_support == ep)
+
+    def test_interpolate_time_support(self, tsdtensor):
+        ep = nap.IntervalSet(tsdtensor.time_support.start[0] + 1, tsdtensor.time_support.end[0] - 1)
+        ts = nap.Ts(np.linspace(0, 10, 20))
+        out = tsdtensor.interpolate(ts, ep=ep)
+        assert np.all(out.time_support == ep)
 
     def test_return_ndarray(self, tsdtensor):
         np.testing.assert_array_equal(tsdtensor[0], tsdtensor.values[0])

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -650,18 +650,30 @@ class TestTimeSeriesGeneral:
 )
 class TestTsd:
 
-    def test_bin_average_time_support(self, tsd):
-        ep = nap.IntervalSet(tsd.time_support.start[0] + 1, tsd.time_support.end[0] - 1)
+    @pytest.mark.parametrize("delta_ep", [(1, -1), (-1, -1), (1, 1)])
+    def test_bin_average_time_support(self, tsd, delta_ep):
+        ep = nap.IntervalSet(
+            tsd.time_support.start[0] + delta_ep[0],
+            tsd.time_support.end[0] + delta_ep[1],
+        )
         out = tsd.bin_average(0.1, ep=ep)
         assert np.all(out.time_support == ep)
 
-    def test_convolve_time_support(self, tsd):
-        ep = nap.IntervalSet(tsd.time_support.start[0] + 1, tsd.time_support.end[0] - 1)
+    @pytest.mark.parametrize("delta_ep", [(1, -1), (-1, -1), (1, 1)])
+    def test_convolve_time_support(self, tsd, delta_ep):
+        ep = nap.IntervalSet(
+            tsd.time_support.start[0] + delta_ep[0],
+            tsd.time_support.end[0] + delta_ep[1],
+        )
         out = tsd.convolve(np.ones(10), ep=ep)
         assert np.all(out.time_support == ep)
 
-    def test_interpolate_time_support(self, tsd):
-        ep = nap.IntervalSet(tsd.time_support.start[0] + 1, tsd.time_support.end[0] - 1)
+    @pytest.mark.parametrize("delta_ep", [(1, -1), (-1, -1), (1, 1)])
+    def test_interpolate_time_support(self, tsd, delta_ep):
+        ep = nap.IntervalSet(
+            tsd.time_support.start[0] + delta_ep[0],
+            tsd.time_support.end[0] + delta_ep[1],
+        )
         ts = nap.Ts(np.linspace(0, 10, 20))
         out = tsd.interpolate(ts, ep=ep)
         assert np.all(out.time_support == ep)
@@ -996,23 +1008,29 @@ class TestTsd:
 )
 class TestTsdFrame:
 
-    def test_bin_average_time_support(self, tsdframe):
+    @pytest.mark.parametrize("delta_ep", [(1, -1), (-1, -1), (1, 1)])
+    def test_bin_average_time_support(self, tsdframe, delta_ep):
         ep = nap.IntervalSet(
-            tsdframe.time_support.start[0] + 1, tsdframe.time_support.end[0] - 1
+            tsdframe.time_support.start[0] + delta_ep[0],
+            tsdframe.time_support.end[0] + delta_ep[1],
         )
         out = tsdframe.bin_average(0.1, ep=ep)
         assert np.all(out.time_support == ep)
 
-    def test_convolve_time_support(self, tsdframe):
+    @pytest.mark.parametrize("delta_ep", [(1, -1), (-1, -1), (1, 1)])
+    def test_convolve_time_support(self, tsdframe, delta_ep):
         ep = nap.IntervalSet(
-            tsdframe.time_support.start[0] + 1, tsdframe.time_support.end[0] - 1
+            tsdframe.time_support.start[0] + delta_ep[0],
+            tsdframe.time_support.end[0] + delta_ep[1],
         )
         out = tsdframe.convolve(np.ones(10), ep=ep)
         assert np.all(out.time_support == ep)
 
-    def test_interpolate_time_support(self, tsdframe):
+    @pytest.mark.parametrize("delta_ep", [(1, -1), (-1, -1), (1, 1)])
+    def test_interpolate_time_support(self, tsdframe, delta_ep):
         ep = nap.IntervalSet(
-            tsdframe.time_support.start[0] + 1, tsdframe.time_support.end[0] - 1
+            tsdframe.time_support.start[0] + delta_ep[0],
+            tsdframe.time_support.end[0] + delta_ep[1],
         )
         ts = nap.Ts(np.linspace(0, 10, 20))
         out = tsdframe.interpolate(ts, ep=ep)
@@ -1629,23 +1647,29 @@ class TestTs:
 )
 class TestTsdTensor:
 
-    def test_bin_average_time_support(self, tsdtensor):
+    @pytest.mark.parametrize("delta_ep", [(1, -1), (-1, -1), (1, 1)])
+    def test_bin_average_time_support(self, delta_ep, tsdtensor):
         ep = nap.IntervalSet(
-            tsdtensor.time_support.start[0] + 1, tsdtensor.time_support.end[0] - 1
+            tsdtensor.time_support.start[0] + delta_ep[0],
+            tsdtensor.time_support.end[0] + delta_ep[1],
         )
         out = tsdtensor.bin_average(0.1, ep=ep)
         assert np.all(out.time_support == ep)
 
-    def test_convolve_time_support(self, tsdtensor):
+    @pytest.mark.parametrize("delta_ep", [(1, -1), (-1, -1), (1, 1)])
+    def test_convolve_time_support(self, tsdtensor, delta_ep):
         ep = nap.IntervalSet(
-            tsdtensor.time_support.start[0] + 1, tsdtensor.time_support.end[0] - 1
+            tsdtensor.time_support.start[0] + delta_ep[0],
+            tsdtensor.time_support.end[0] + delta_ep[1],
         )
         out = tsdtensor.convolve(np.ones(10), ep=ep)
         assert np.all(out.time_support == ep)
 
-    def test_interpolate_time_support(self, tsdtensor):
+    @pytest.mark.parametrize("delta_ep", [(1, -1), (-1, -1), (1, 1)])
+    def test_interpolate_time_support(self, tsdtensor, delta_ep):
         ep = nap.IntervalSet(
-            tsdtensor.time_support.start[0] + 1, tsdtensor.time_support.end[0] - 1
+            tsdtensor.time_support.start[0] + delta_ep[0],
+            tsdtensor.time_support.end[0] + delta_ep[1],
         )
         ts = nap.Ts(np.linspace(0, 10, 20))
         out = tsdtensor.interpolate(ts, ep=ep)


### PR DESCRIPTION
Some of the methods of Tsd were not overwriting the epochs when `ep` was provided (like bin_average. or interpolate).
Fix the issue with this PR to fix the behavior of these operation. Added tests.