### PR TITLE
Update the definition of `compute_power_spectral_density` to compute the true PSD

### DIFF
--- a/doc/external.md
+++ b/doc/external.md
@@ -8,11 +8,11 @@ As such, it can function as a foundational element for other analysis packages h
 
 ![image](https://raw.githubusercontent.com/flatironinstitute/nemos/main/docs/assets/glm_features_scheme.svg)
 
-[NeMoS](https://nemos.readthedocs.io/en/stable/) is a statistical modeling framework optimized for systems neuroscience and powered by JAX. It streamlines the process of defining and selecting models, through a collection of easy-to-use methods for feature design.
+[NeMoS](https://nemos.readthedocs.io/en/latest/index.html) is a statistical modeling framework optimized for systems neuroscience and powered by JAX. It streamlines the process of defining and selecting models, through a collection of easy-to-use methods for feature design.
 
 The core of nemos includes GPU-accelerated, well-tested implementations of standard statistical models, currently focusing on the Generalized Linear Model (GLM). 
 
-Check out this [page](https://nemos.readthedocs.io/en/stable/generated/neural_modeling/) for many examples of neural modelling using nemos and pynapple.
+Check out this [page](https://nemos.readthedocs.io/en/latest/tutorials/README.html) for many examples of neural modelling using nemos and pynapple.
 
 ```{eval-rst}
 .. Note::

--- a/pynapple/process/__init__.py
+++ b/pynapple/process/__init__.py
@@ -22,11 +22,7 @@ from .randomize import (
     shift_timestamps,
     shuffle_ts_intervals,
 )
-from .spectrum import (
-    compute_fft,
-    compute_mean_fft,
-    compute_power_spectral_density,
-)
+from .spectrum import compute_fft, compute_mean_fft, compute_power_spectral_density
 from .tuning_curves import (
     compute_1d_mutual_info,
     compute_1d_tuning_curves,

--- a/pynapple/process/__init__.py
+++ b/pynapple/process/__init__.py
@@ -23,9 +23,9 @@ from .randomize import (
     shuffle_ts_intervals,
 )
 from .spectrum import (
-    compute_mean_power_spectral_density,
-    compute_power_spectral_density,
     compute_fft,
+    compute_mean_fft,
+    compute_power_spectral_density,
 )
 from .tuning_curves import (
     compute_1d_mutual_info,

--- a/pynapple/process/__init__.py
+++ b/pynapple/process/__init__.py
@@ -25,6 +25,7 @@ from .randomize import (
 from .spectrum import (
     compute_mean_power_spectral_density,
     compute_power_spectral_density,
+    compute_fft,
 )
 from .tuning_curves import (
     compute_1d_mutual_info,

--- a/pynapple/process/spectrum.py
+++ b/pynapple/process/spectrum.py
@@ -160,7 +160,9 @@ def compute_power_spectral_density(sig, fs=None, ep=None, full_range=False, n=No
     # subtract from the nyquist frequency to adjust for floating point error in np.fft.fftfreq
     # nyquist freq may occur at negative end of frequencies if N is even
     doubled_freqs = (
-        (fft.index != 0) & (fft.index < (fs / 2 - 1e-6)) & (fft.index > (fs / 2 + 1e-6))
+        (fft.index != 0)  # not 0
+        & (fft.index < (fs / 2 - 1e-6))  # less than positive nyquist freq
+        & (fft.index > (-fs / 2 + 1e-6))  # greater than negative nyquist freq
     )
     psd[doubled_freqs] *= 2
 

--- a/pynapple/process/spectrum.py
+++ b/pynapple/process/spectrum.py
@@ -156,15 +156,16 @@ def compute_power_spectral_density(sig, fs=None, ep=None, full_range=False, n=No
     # transform to power spectral density, power/Hz
     psd = (1 / (fs * n)) * np.abs(fft) ** 2
 
-    # frequencies not at 0 and not at the nyquist frequency occur twice
-    # subtract from the nyquist frequency to adjust for floating point error in np.fft.fftfreq
-    # nyquist freq may occur at negative end of frequencies if N is even
-    doubled_freqs = (
-        (fft.index != 0)  # not 0
-        & (fft.index < (fs / 2 - 1e-6))  # less than positive nyquist freq
-        & (fft.index > (-fs / 2 + 1e-6))  # greater than negative nyquist freq
-    )
-    psd[doubled_freqs] *= 2
+    if full_range is False:
+        # frequencies not at 0 and not at the nyquist frequency occur twice
+        # subtract from the nyquist frequency to adjust for floating point error in np.fft.fftfreq
+        # nyquist freq may occur at negative end of frequencies if N is even
+        doubled_freqs = (
+            (fft.index != 0)  # not 0
+            & (fft.index < (fs / 2 - 1e-6))  # less than positive nyquist freq
+            & (fft.index > (-fs / 2 + 1e-6))  # greater than negative nyquist freq
+        )
+        psd[doubled_freqs] *= 2
 
     return psd
 

--- a/pynapple/process/spectrum.py
+++ b/pynapple/process/spectrum.py
@@ -168,7 +168,7 @@ def compute_power_spectral_density(sig, fs=None, ep=None, full_range=False, n=No
 
 
 @_validate_spectrum_inputs
-def compute_mean_power_spectral_density(
+def compute_mean_fft(
     sig,
     interval_size,
     fs=None,

--- a/pynapple/process/spectrum.py
+++ b/pynapple/process/spectrum.py
@@ -136,7 +136,7 @@ def compute_power_spectral_density(sig, fs=None, ep=None, n=None):
     See [this tutorial](https://www.mathworks.com/help/signal/ug/power-spectral-density-estimates-using-fft.html) for more information.
     """
 
-    fft = nap.compute_fft(sig, fs=fs, ep=ep, n=n)
+    fft = compute_fft(sig, fs=fs, ep=ep, n=n)
     N = len(sig.restrict(ep))
 
     # transform to power spectral density, power/Hz

--- a/tests/test_power_spectral_density.py
+++ b/tests/test_power_spectral_density.py
@@ -22,6 +22,14 @@ def get_sorted_fft(data, fs):
     return fft_freq[order], fft[order]
 
 
+def get_periodogram(data, fs):
+    f, p = signal.periodogram(data, fs, return_onesided=False, detrend=False, axis=0)
+    order = np.argsort(f)
+    if p.ndim == 1:
+        p = p[:, np.newaxis]
+    return f[order], p[order]
+
+
 def test_compute_fft():
 
     t = np.linspace(0, 1, 1000)
@@ -68,50 +76,47 @@ def test_compute_fft():
     assert r.shape[0] == 500
 
 
-# def test_compute_power_spectral_density():
+def test_compute_power_spectral_density():
 
-#     t = np.linspace(0, 1, 1000)
-#     sig = nap.Tsd(d=np.random.random(1000), t=t)
-#     r = nap.compute_power_spectral_density(sig)
-#     assert isinstance(r, pd.DataFrame)
-#     assert r.shape[0] == 500
+    t = np.linspace(0, 1, 1000)
+    sig = nap.Tsd(d=np.random.random(1000), t=t)
+    r = nap.compute_power_spectral_density(sig)
+    assert isinstance(r, pd.DataFrame)
+    assert r.shape[0] == 500
 
-#     a, b = get_sorted_fft(sig.values, sig.rate)
-#     np.testing.assert_array_almost_equal(r.index.values, a[a >= 0])
-#     np.testing.assert_array_almost_equal(r.values, b[a >= 0])
+    a, b = get_periodogram(sig.values, sig.rate)
+    np.testing.assert_array_almost_equal(r.index.values, a[a >= 0])
+    np.testing.assert_array_almost_equal(r.values, b[a >= 0])
 
-#     r = nap.compute_power_spectral_density(sig, norm=True)
-#     np.testing.assert_array_almost_equal(r.values, b[a >= 0] / len(sig))
+    sig = nap.TsdFrame(d=np.random.random((1000, 4)), t=t)
+    r = nap.compute_power_spectral_density(sig)
+    assert isinstance(r, pd.DataFrame)
+    assert r.shape == (500, 4)
 
-#     sig = nap.TsdFrame(d=np.random.random((1000, 4)), t=t)
-#     r = nap.compute_power_spectral_density(sig)
-#     assert isinstance(r, pd.DataFrame)
-#     assert r.shape == (500, 4)
+    a, b = get_periodogram(sig.values, sig.rate)
+    np.testing.assert_array_almost_equal(r.index.values, a[a >= 0])
+    np.testing.assert_array_almost_equal(r.values, b[a >= 0])
 
-#     a, b = get_sorted_fft(sig.values, sig.rate)
-#     np.testing.assert_array_almost_equal(r.index.values, a[a >= 0])
-#     np.testing.assert_array_almost_equal(r.values, b[a >= 0])
+    sig = nap.TsdFrame(d=np.random.random((1000, 4)), t=t)
+    r = nap.compute_power_spectral_density(sig, full_range=True)
+    assert isinstance(r, pd.DataFrame)
+    assert r.shape == (1000, 4)
 
-#     sig = nap.TsdFrame(d=np.random.random((1000, 4)), t=t)
-#     r = nap.compute_power_spectral_density(sig, full_range=True)
-#     assert isinstance(r, pd.DataFrame)
-#     assert r.shape == (1000, 4)
+    a, b = get_periodogram(sig.values, sig.rate)
+    np.testing.assert_array_almost_equal(r.index.values, a)
+    np.testing.assert_array_almost_equal(r.values, b)
 
-#     a, b = get_sorted_fft(sig.values, sig.rate)
-#     np.testing.assert_array_almost_equal(r.index.values, a)
-#     np.testing.assert_array_almost_equal(r.values, b)
+    t = np.linspace(0, 1, 1000)
+    sig = nap.Tsd(d=np.random.random(1000), t=t)
+    r = nap.compute_power_spectral_density(sig, ep=sig.time_support)
+    assert isinstance(r, pd.DataFrame)
+    assert r.shape[0] == 500
 
-#     t = np.linspace(0, 1, 1000)
-#     sig = nap.Tsd(d=np.random.random(1000), t=t)
-#     r = nap.compute_power_spectral_density(sig, ep=sig.time_support)
-#     assert isinstance(r, pd.DataFrame)
-#     assert r.shape[0] == 500
-
-#     t = np.linspace(0, 1, 1000)
-#     sig = nap.Tsd(d=np.random.random(1000), t=t)
-#     r = nap.compute_power_spectral_density(sig, fs=1000)
-#     assert isinstance(r, pd.DataFrame)
-#     assert r.shape[0] == 500
+    t = np.linspace(0, 1, 1000)
+    sig = nap.Tsd(d=np.random.random(1000), t=t)
+    r = nap.compute_power_spectral_density(sig, fs=1000)
+    assert isinstance(r, pd.DataFrame)
+    assert r.shape[0] == 500
 
 
 @pytest.mark.parametrize(
@@ -184,6 +189,9 @@ def test_compute_fft():
 def test_compute_fft_raise_errors(sig, kwargs, expectation):
     with expectation:
         nap.compute_fft(sig, **kwargs)
+    if "norm" not in kwargs:
+        with expectation:
+            nap.compute_power_spectral_density(sig, **kwargs)
 
 
 ############################################################

--- a/tests/test_power_spectral_density.py
+++ b/tests/test_power_spectral_density.py
@@ -22,12 +22,21 @@ def get_sorted_fft(data, fs):
     return fft_freq[order], fft[order]
 
 
-def get_periodogram(data, fs):
-    f, p = signal.periodogram(data, fs, return_onesided=False, detrend=False, axis=0)
-    order = np.argsort(f)
+def get_periodogram(data, fs, full_range=False):
+    return_onesided = not full_range
+    f, p = signal.periodogram(
+        data, fs, return_onesided=return_onesided, detrend=False, axis=0
+    )
     if p.ndim == 1:
         p = p[:, np.newaxis]
-    return f[order], p[order]
+    if full_range:
+        order = np.argsort(f)
+        f = f[order]
+        p = p[order]
+    else:
+        f = f[:-1]
+        p = p[:-1]
+    return f, p
 
 
 def test_compute_fft():
@@ -102,7 +111,7 @@ def test_compute_power_spectral_density():
     assert isinstance(r, pd.DataFrame)
     assert r.shape == (1000, 4)
 
-    a, b = get_periodogram(sig.values, sig.rate)
+    a, b = get_periodogram(sig.values, sig.rate, full_range=True)
     np.testing.assert_array_almost_equal(r.index.values, a)
     np.testing.assert_array_almost_equal(r.values, b)
 

--- a/tests/test_power_spectral_density.py
+++ b/tests/test_power_spectral_density.py
@@ -226,23 +226,23 @@ def get_signal_and_output(f=2, fs=1000, duration=100, interval_size=10, overlap=
     return (sig, out, freq)
 
 
-def test_compute_mean_power_spectral_density():
+def test_compute_mean_fft():
     sig, out, freq = get_signal_and_output()
-    psd = nap.compute_mean_power_spectral_density(sig, 10)
+    psd = nap.compute_mean_fft(sig, 10)
     assert isinstance(psd, pd.DataFrame)
     assert psd.shape[0] > 0  # Check that the psd DataFrame is not empty
     np.testing.assert_array_almost_equal(psd.values.flatten(), out[freq >= 0])
     np.testing.assert_array_almost_equal(psd.index.values, freq[freq >= 0])
 
     # Full range
-    psd = nap.compute_mean_power_spectral_density(sig, 10, full_range=True)
+    psd = nap.compute_mean_fft(sig, 10, full_range=True)
     assert isinstance(psd, pd.DataFrame)
     assert psd.shape[0] > 0  # Check that the psd DataFrame is not empty
     np.testing.assert_array_almost_equal(psd.values.flatten(), out)
     np.testing.assert_array_almost_equal(psd.index.values, freq)
 
     # Norm
-    psd = nap.compute_mean_power_spectral_density(sig, 10, norm=True)
+    psd = nap.compute_mean_fft(sig, 10, norm=True)
     assert isinstance(psd, pd.DataFrame)
     assert psd.shape[0] > 0  # Check that the psd DataFrame is not empty
     np.testing.assert_array_almost_equal(
@@ -254,7 +254,7 @@ def test_compute_mean_power_spectral_density():
     sig2 = nap.TsdFrame(
         t=sig.t, d=np.repeat(sig.values[:, None], 2, 1), time_support=sig.time_support
     )
-    psd = nap.compute_mean_power_spectral_density(sig2, 10, full_range=True)
+    psd = nap.compute_mean_fft(sig2, 10, full_range=True)
     assert isinstance(psd, pd.DataFrame)
     assert psd.shape[0] > 0  # Check that the psd DataFrame is not empty
     np.testing.assert_array_almost_equal(psd.values, np.repeat(out[:, None], 2, 1))
@@ -264,7 +264,7 @@ def test_compute_mean_power_spectral_density():
     sig2 = nap.TsdFrame(
         t=sig.t, d=np.repeat(sig.values[:, None], 2, 1), time_support=sig.time_support
     )
-    psd = nap.compute_mean_power_spectral_density(sig2, 10, full_range=True, fs=1000)
+    psd = nap.compute_mean_fft(sig2, 10, full_range=True, fs=1000)
     assert isinstance(psd, pd.DataFrame)
     assert psd.shape[0] > 0  # Check that the psd DataFrame is not empty
     np.testing.assert_array_almost_equal(psd.values, np.repeat(out[:, None], 2, 1))
@@ -383,8 +383,6 @@ def test_compute_mean_power_spectral_density():
         ),
     ],
 )
-def test_compute_mean_power_spectral_density_raise_errors(
-    sig, interval_size, kwargs, expectation
-):
+def test_compute_mean_fft_raise_errors(sig, interval_size, kwargs, expectation):
     with expectation:
-        nap.compute_mean_power_spectral_density(sig, interval_size, **kwargs)
+        nap.compute_mean_fft(sig, interval_size, **kwargs)

--- a/tests/test_power_spectral_density.py
+++ b/tests/test_power_spectral_density.py
@@ -22,11 +22,11 @@ def get_sorted_fft(data, fs):
     return fft_freq[order], fft[order]
 
 
-def test_compute_power_spectral_density():
+def test_compute_fft():
 
     t = np.linspace(0, 1, 1000)
     sig = nap.Tsd(d=np.random.random(1000), t=t)
-    r = nap.compute_power_spectral_density(sig)
+    r = nap.compute_fft(sig)
     assert isinstance(r, pd.DataFrame)
     assert r.shape[0] == 500
 
@@ -34,11 +34,11 @@ def test_compute_power_spectral_density():
     np.testing.assert_array_almost_equal(r.index.values, a[a >= 0])
     np.testing.assert_array_almost_equal(r.values, b[a >= 0])
 
-    r = nap.compute_power_spectral_density(sig, norm=True)
+    r = nap.compute_fft(sig, norm=True)
     np.testing.assert_array_almost_equal(r.values, b[a >= 0] / len(sig))
 
     sig = nap.TsdFrame(d=np.random.random((1000, 4)), t=t)
-    r = nap.compute_power_spectral_density(sig)
+    r = nap.compute_fft(sig)
     assert isinstance(r, pd.DataFrame)
     assert r.shape == (500, 4)
 
@@ -47,7 +47,7 @@ def test_compute_power_spectral_density():
     np.testing.assert_array_almost_equal(r.values, b[a >= 0])
 
     sig = nap.TsdFrame(d=np.random.random((1000, 4)), t=t)
-    r = nap.compute_power_spectral_density(sig, full_range=True)
+    r = nap.compute_fft(sig, full_range=True)
     assert isinstance(r, pd.DataFrame)
     assert r.shape == (1000, 4)
 
@@ -57,15 +57,61 @@ def test_compute_power_spectral_density():
 
     t = np.linspace(0, 1, 1000)
     sig = nap.Tsd(d=np.random.random(1000), t=t)
-    r = nap.compute_power_spectral_density(sig, ep=sig.time_support)
+    r = nap.compute_fft(sig, ep=sig.time_support)
     assert isinstance(r, pd.DataFrame)
     assert r.shape[0] == 500
 
     t = np.linspace(0, 1, 1000)
     sig = nap.Tsd(d=np.random.random(1000), t=t)
-    r = nap.compute_power_spectral_density(sig, fs=1000)
+    r = nap.compute_fft(sig, fs=1000)
     assert isinstance(r, pd.DataFrame)
     assert r.shape[0] == 500
+
+
+# def test_compute_power_spectral_density():
+
+#     t = np.linspace(0, 1, 1000)
+#     sig = nap.Tsd(d=np.random.random(1000), t=t)
+#     r = nap.compute_power_spectral_density(sig)
+#     assert isinstance(r, pd.DataFrame)
+#     assert r.shape[0] == 500
+
+#     a, b = get_sorted_fft(sig.values, sig.rate)
+#     np.testing.assert_array_almost_equal(r.index.values, a[a >= 0])
+#     np.testing.assert_array_almost_equal(r.values, b[a >= 0])
+
+#     r = nap.compute_power_spectral_density(sig, norm=True)
+#     np.testing.assert_array_almost_equal(r.values, b[a >= 0] / len(sig))
+
+#     sig = nap.TsdFrame(d=np.random.random((1000, 4)), t=t)
+#     r = nap.compute_power_spectral_density(sig)
+#     assert isinstance(r, pd.DataFrame)
+#     assert r.shape == (500, 4)
+
+#     a, b = get_sorted_fft(sig.values, sig.rate)
+#     np.testing.assert_array_almost_equal(r.index.values, a[a >= 0])
+#     np.testing.assert_array_almost_equal(r.values, b[a >= 0])
+
+#     sig = nap.TsdFrame(d=np.random.random((1000, 4)), t=t)
+#     r = nap.compute_power_spectral_density(sig, full_range=True)
+#     assert isinstance(r, pd.DataFrame)
+#     assert r.shape == (1000, 4)
+
+#     a, b = get_sorted_fft(sig.values, sig.rate)
+#     np.testing.assert_array_almost_equal(r.index.values, a)
+#     np.testing.assert_array_almost_equal(r.values, b)
+
+#     t = np.linspace(0, 1, 1000)
+#     sig = nap.Tsd(d=np.random.random(1000), t=t)
+#     r = nap.compute_power_spectral_density(sig, ep=sig.time_support)
+#     assert isinstance(r, pd.DataFrame)
+#     assert r.shape[0] == 500
+
+#     t = np.linspace(0, 1, 1000)
+#     sig = nap.Tsd(d=np.random.random(1000), t=t)
+#     r = nap.compute_power_spectral_density(sig, fs=1000)
+#     assert isinstance(r, pd.DataFrame)
+#     assert r.shape[0] == 500
 
 
 @pytest.mark.parametrize(
@@ -135,9 +181,9 @@ def test_compute_power_spectral_density():
         ),
     ],
 )
-def test_compute_power_spectral_density_raise_errors(sig, kwargs, expectation):
+def test_compute_fft_raise_errors(sig, kwargs, expectation):
     with expectation:
-        nap.compute_power_spectral_density(sig, **kwargs)
+        nap.compute_fft(sig, **kwargs)
 
 
 ############################################################

--- a/tests/test_signal_processing.py
+++ b/tests/test_signal_processing.py
@@ -15,7 +15,7 @@ def test_generate_morlet_filterbank():
     fb = nap.generate_morlet_filterbank(
         freqs, fs, gaussian_width=1.5, window_length=1.0, precision=16
     )
-    power = np.abs(nap.compute_power_spectral_density(fb))
+    power = np.abs(nap.compute_fft(fb))
     for i, f in enumerate(freqs):
         # Check that peak freq matched expectation
         assert power.iloc[:, i].argmax() == np.abs(power.index - f).argmin()
@@ -25,7 +25,7 @@ def test_generate_morlet_filterbank():
     fb = nap.generate_morlet_filterbank(
         freqs, fs, gaussian_width=1.5, window_length=1.0, precision=16
     )
-    power = np.abs(nap.compute_power_spectral_density(fb))
+    power = np.abs(nap.compute_fft(fb))
     for i, f in enumerate(freqs):
         # Check that peak freq matched expectation
         assert power.iloc[:, i].argmax() == np.abs(power.index - f).argmin()
@@ -35,7 +35,7 @@ def test_generate_morlet_filterbank():
     fb = nap.generate_morlet_filterbank(
         freqs, fs, gaussian_width=3.5, window_length=1.0, precision=16
     )
-    power = np.abs(nap.compute_power_spectral_density(fb))
+    power = np.abs(nap.compute_fft(fb))
     for i, f in enumerate(freqs):
         # Check that peak freq matched expectation
         assert power.iloc[:, i].argmax() == np.abs(power.index - f).argmin()
@@ -45,7 +45,7 @@ def test_generate_morlet_filterbank():
     fb = nap.generate_morlet_filterbank(
         freqs, fs, gaussian_width=3.5, window_length=1.0, precision=16
     )
-    power = np.abs(nap.compute_power_spectral_density(fb))
+    power = np.abs(nap.compute_fft(fb))
     for i, f in enumerate(freqs):
         # Check that peak freq matched expectation
         assert power.iloc[:, i].argmax() == np.abs(power.index - f).argmin()
@@ -55,7 +55,7 @@ def test_generate_morlet_filterbank():
     fb = nap.generate_morlet_filterbank(
         freqs, fs, gaussian_width=1.5, window_length=3.0, precision=16
     )
-    power = np.abs(nap.compute_power_spectral_density(fb))
+    power = np.abs(nap.compute_fft(fb))
     for i, f in enumerate(freqs):
         # Check that peak freq matched expectation
         assert power.iloc[:, i].argmax() == np.abs(power.index - f).argmin()
@@ -65,7 +65,7 @@ def test_generate_morlet_filterbank():
     fb = nap.generate_morlet_filterbank(
         freqs, fs, gaussian_width=1.5, window_length=3.0, precision=16
     )
-    power = np.abs(nap.compute_power_spectral_density(fb))
+    power = np.abs(nap.compute_fft(fb))
     for i, f in enumerate(freqs):
         # Check that peak freq matched expectation
         assert power.iloc[:, i].argmax() == np.abs(power.index - f).argmin()
@@ -77,7 +77,7 @@ def test_generate_morlet_filterbank():
     fb = nap.generate_morlet_filterbank(
         freqs, fs, gaussian_width=1.0, window_length=1.0, precision=24
     )
-    power = np.abs(nap.compute_power_spectral_density(fb))
+    power = np.abs(nap.compute_fft(fb))
     for i, f in enumerate(freqs):
         gaussian_width = 1.0
         window_length = 1.0
@@ -97,7 +97,7 @@ def test_generate_morlet_filterbank():
     fb = nap.generate_morlet_filterbank(
         freqs, fs, gaussian_width=1.0, window_length=1.0, precision=24
     )
-    power = np.abs(nap.compute_power_spectral_density(fb))
+    power = np.abs(nap.compute_fft(fb))
     for i, f in enumerate(freqs):
         gaussian_width = 1.0
         window_length = 1.0
@@ -117,7 +117,7 @@ def test_generate_morlet_filterbank():
     fb = nap.generate_morlet_filterbank(
         freqs, fs, gaussian_width=4.0, window_length=1.0, precision=24
     )
-    power = np.abs(nap.compute_power_spectral_density(fb))
+    power = np.abs(nap.compute_fft(fb))
     for i, f in enumerate(freqs):
         gaussian_width = 4.0
         window_length = 1.0
@@ -137,7 +137,7 @@ def test_generate_morlet_filterbank():
     fb = nap.generate_morlet_filterbank(
         freqs, fs, gaussian_width=4.0, window_length=3.0, precision=24
     )
-    power = np.abs(nap.compute_power_spectral_density(fb))
+    power = np.abs(nap.compute_fft(fb))
     for i, f in enumerate(freqs):
         gaussian_width = 4.0
         window_length = 3.0
@@ -157,7 +157,7 @@ def test_generate_morlet_filterbank():
     fb = nap.generate_morlet_filterbank(
         freqs, fs, gaussian_width=3.5, window_length=1.25, precision=24
     )
-    power = np.abs(nap.compute_power_spectral_density(fb))
+    power = np.abs(nap.compute_fft(fb))
     for i, f in enumerate(freqs):
         gaussian_width = 3.5
         window_length = 1.25


### PR DESCRIPTION
This PR updates the functionality of `compute_power_spectral_density` to actually compute the periodogram, where previously it was only computing the FFT. Additionally, a new function `compute_fft` has been added that contains the old functionality of `compute_power_spectral_density`.