### PR TITLE
Fix value printing of IntervalSet when rows are collapsed

### DIFF
--- a/pynapple/core/interval_set.py
+++ b/pynapple/core/interval_set.py
@@ -336,7 +336,7 @@ class IntervalSet(NDArrayOperatorsMixin, _MetadataMixin):
                     np.hstack(
                         (
                             self.index[-n_rows:, None],
-                            self.values[0:n_rows],
+                            self.values[-n_rows:],
                             _convert_iter_to_str(metadata.values[-n_rows:]),
                         ),
                         dtype=object,


### PR DESCRIPTION
The wrong values were getting printed on the bottom rows of the `__repr__` when rows are collapsed from a small terminal size