### PR TITLE
don't always raise deprecation warning

### DIFF
--- a/pynapple/io/loader.py
+++ b/pynapple/io/loader.py
@@ -18,8 +18,6 @@ import pandas as pd
 
 from .. import core as nap
 
-warnings.simplefilter("always", DeprecationWarning)
-
 
 def get_error_text(path):
     try:


### PR DESCRIPTION
Removes troublesome `warnings.simplefilter` line. This line causes all `DeprecationWarning` to be raised, overriding other configurations, and is a [holdover](https://github.com/pynapple-org/pynapple/commit/416176dc0e8cb7cc3af7ddf4e0bb0c43719c7b24) from the deprecation of the old IO (now, trying to use that interface raises an error).

This behavior led to a strange `sys:1: DeprecationWarning: Call to deprecated function (or staticmethod) _destroy.` warning when importing `pynapple` and then `pynwb` (as we do in [nemos](https://github.com/flatironinstitute/nemos/)).

This happened because numcodecs  v0.15.0 [deprecated several functions](https://github.com/zarr-developers/numcodecs/commit/3a060f436f0935baadc59da5f47ba00f7a6ca440), and numcodecs is imported by zarr, which is imported by hdmf, which is imported by pynwb.

Pynapple no longer raises any `DeprecationWarning`, so this shouldn't affect any behavior in pynapple itself. Let me know if you'd like me to write a test to ensure there's no warning being raised.