### PR TITLE
Publish workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,73 @@
+name: Build and upload to PyPI for pure python
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build and test package
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+        # this is necessary for setuptools_scm to work properly with github
+        # actions, see https://github.com/pypa/setuptools_scm/issues/480 and
+        # https://stackoverflow.com/a/68959339
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.x
+    - name: Build package
+      run: |
+        pip install build
+        python -m build --outdir dist/ --sdist --wheel
+    - name: Check there's only one sdist and one whl file created
+      shell: bash
+        # because the following two tests will be weird otherwise. see
+        # https://askubuntu.com/a/454568 for why this is the right way to handle
+        # it. using [[ BOOLEAN ]] || EXPR is a compact way of writing IF NOT
+        # BOOLEAN THEN EXPR in bash
+      run: |
+        [[ $(find dist/ -type f -name "*whl" -printf x | wc -c) == 1 ]] || exit 1
+        [[ $(find dist/ -type f -name "*tar.gz" -printf x | wc -c) == 1 ]] || exit 1
+    - name: Check setuptools_scm version against git tag
+      shell: bash
+      run: |
+        # we use the error code of this comparison: =~ is bash's regex
+        # operator, so it checks whether the right side is contained in the
+        # left side. In particular, we succeed if the path of the source code
+        # ends in the most recent git tag, fail if it does not.
+        [[ "$(ls dist/*tar.gz)" =~ "-$(git describe --tags).tar.gz" ]]
+    - name: Check we can install from wheel
+        # note that this is how this works in bash (different shells might be
+        # slightly different). we've checked there's only one .whl file in an
+        # earlier step, so the bit in `$()` will expand to that single file,
+        # then we pass [dev] to get specify the optional dev dependencies, and
+        # we wrap the whole thing in quotes so bash doesn't try to interpret the
+        # square brackets but passes them directly to pip install
+      shell: bash
+      run: |
+        pip install "$(ls dist/*whl)[dev]"
+    - name: Run some tests
+        # modify the following as necessary to e.g., run notebooks
+      run: |
+        pytest tests/
+    - uses: actions/upload-artifact@v4
+      with:
+        path: dist/*
+
+  publish:
+    name: Upload release to PyPI
+    needs: [build]
+    environment: pypi
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        name: artifact
+        path: dist
+    - name: Publish package to pypi
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,8 @@ jobs:
         # operator, so it checks whether the right side is contained in the
         # left side. In particular, we succeed if the path of the source code
         # ends in the most recent git tag, fail if it does not.
-        [[ "$(ls dist/*tar.gz)" =~ "-$(git describe --tags).tar.gz" ]]
+        TAG=$(git describe --tags)
+        [[ "$(ls dist/*tar.gz)" =~ "-${TAG:1}.tar.gz" ]]
     - name: Check we can install from wheel
         # note that this is how this works in bash (different shells might be
         # slightly different). we've checked there's only one .whl file in an


### PR DESCRIPTION
This PR adds a new Github workflow file, `deploy.yml`, which will build and publish release to PyPI whenever you release them through Github. In order to make this work, you'll [need to set up trusted publishing](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/), which involves signing into PyPI and basically giving this github repo permission to upload for you (you'll need to specify the workflow's file name, `deploy.yml`).

In addition to building and deploying, this also checks:
- that we only built a single release
- that its version tag matches the most recent git tag
- that we can install from the wheel
- that the tests pass (right now, this is just `pytest tests/`, you could add other stuff if you like; for plenoptic, I also test that I can run the notebooks)

For [plenoptic](https://github.com/plenoptic-org/plenoptic/blob/main/.github/workflows/deploy.yml), I also add a manual `workflow_dispatch` trigger, which will cause the workflow to deploy to Test PyPI instead, just to be sure that everything works. If you'd like to do that as well, you'll need to get the pynapple name on TestPyPI (and also set up trusted publishing there). Nemos does not do that, and it's worked for nemos so far.