### PR TITLE
Fix tsgrouprate

### DIFF
--- a/pynapple/core/ts_group.py
+++ b/pynapple/core/ts_group.py
@@ -285,6 +285,10 @@ class TsGroup(UserDict, _MetadataMixin):
         # Making the TsGroup non mutable
         self._initialized = True
 
+        # Adding manually the rate column if data is empty.
+        if len(data) == 0:
+            self.set_info(rate=[])
+
         # Trying to add argument as metainfo
         if len(kwargs):
             warnings.warn(

--- a/tests/test_ts_group.py
+++ b/tests/test_ts_group.py
@@ -87,6 +87,14 @@ class TestTsGroup1:
         with expectation:
             nap.TsGroup(test_dict)
 
+    def test_create_empty_tsgroup(self):
+        tsgroup = nap.TsGroup(data={}, time_support=nap.IntervalSet(0, 1))
+
+        assert isinstance(tsgroup, nap.TsGroup)
+        assert len(tsgroup) == 0
+        # Need to make sure the metadata has the rate attribute
+        assert "rate" in tsgroup.metadata.columns
+
     @pytest.mark.parametrize(
         "tsgroup",
         [


### PR DESCRIPTION
When initializing empty TsGroup, the rate attribute was not added to the metadata dataframe.

