### PR TITLE
make GHA checkout grab git tags

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,6 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        # this is necessary for setuptools_scm to work properly with github
+        # actions, see https://github.com/pypa/setuptools_scm/issues/480 and
+        # https://stackoverflow.com/a/68959339
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
       - name: Install dependencies
         run: |


### PR DESCRIPTION
By default, `actions/checkout` doesn't grab git tags (see https://github.com/pypa/setuptools_scm/issues/480 and https://stackoverflow.com/a/68959339), which means that the version that sphinx was grabbing was wrong. This fixes that.