### PR TITLE
Preserve metadata when calling `count` on a `TsGroup`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ your
 
 # Ignore npz files from testing:
 tests/*.npz
+.vscode/settings.json

--- a/pynapple/core/ts_group.py
+++ b/pynapple/core/ts_group.py
@@ -720,11 +720,26 @@ class TsGroup(UserDict, _MetadataMixin):
                     dtype=dtype,
                 )[1]
 
-            return TsdFrame(t=time_index, d=count, time_support=ep, columns=self.index)
+            metadata = self._metadata.copy()
+            # store a more informative rate
+            metadata["rate"] = count.sum(axis=0) / np.sum(ends - starts)
+            with warnings.catch_warnings():
+                # ignore warning about "rate" metadata
+                warnings.filterwarnings("ignore", message="Metadata name 'rate'")
+                return TsdFrame(
+                    t=time_index,
+                    d=count,
+                    time_support=ep,
+                    columns=self.index,
+                    metadata=metadata,
+                )
         else:
             time_index, _ = _count(np.array([]), starts, ends, bin_size, dtype=dtype)
             return TsdFrame(
-                t=time_index, d=np.empty((len(time_index), 0)), time_support=ep
+                t=time_index,
+                d=np.empty((len(time_index), 0)),
+                time_support=ep,
+                metadata=self._metadata,
             )
 
     def to_tsd(self, *args):


### PR DESCRIPTION
This PR modifies the `TsGroup` `count` method to preserve metadata and pass it to the resulting `TsdFrame`. Additionally, it recomputes the "rate" metadata to be specific to the interval over which `count` was called.

I added checks for metadata to two tests in `test_ts_group.py`: `test_count` and `test_count_with_ep`. More generally, I refactored both of these tests to use parametrization to test more intervals and bin sizes, as well as checking the count results against similar numpy functions.