### PR TITLE
drop rate metadata when using count

### DIFF
--- a/pynapple/core/ts_group.py
+++ b/pynapple/core/ts_group.py
@@ -721,25 +721,22 @@ class TsGroup(UserDict, _MetadataMixin):
                 )[1]
 
             metadata = self._metadata.copy()
-            # store a more informative rate
-            metadata["rate"] = count.sum(axis=0) / np.sum(ends - starts)
-            with warnings.catch_warnings():
-                # ignore warning about "rate" metadata
-                warnings.filterwarnings("ignore", message="Metadata name 'rate'")
-                return TsdFrame(
-                    t=time_index,
-                    d=count,
-                    time_support=ep,
-                    columns=self.index,
-                    metadata=metadata,
-                )
+            # drop rate from metadata
+            metadata = metadata.drop(columns=["rate"])
+            return TsdFrame(
+                t=time_index,
+                d=count,
+                time_support=ep,
+                columns=self.index,
+                metadata=metadata,
+            )
         else:
             time_index, _ = _count(np.array([]), starts, ends, bin_size, dtype=dtype)
             return TsdFrame(
                 t=time_index,
                 d=np.empty((len(time_index), 0)),
                 time_support=ep,
-                metadata=self._metadata,
+                metadata=self._metadata.drop(columns=["rate"]),
             )
 
     def to_tsd(self, *args):

--- a/tests/test_ts_group.py
+++ b/tests/test_ts_group.py
@@ -372,10 +372,6 @@ class TestTsGroup1:
 
         res = np.array(res).T
         np.testing.assert_array_almost_equal(count.values, res)
-        # check rate
-        np.testing.assert_array_almost_equal(
-            count.get_info("rate").values, np.sum(res, axis=0) / dt
-        )
         # check metadata
         if metadata is not None:
             pd.testing.assert_series_equal(
@@ -435,10 +431,6 @@ class TestTsGroup1:
 
         res = np.array(res).T
         np.testing.assert_array_almost_equal(count.values, res)
-        # check rate
-        np.testing.assert_array_almost_equal(
-            count.get_info("rate").values, np.sum(res, axis=0) / dt
-        )
         # check metadata
         if metadata is not None:
             pd.testing.assert_series_equal(


### PR DESCRIPTION
when preserving `TsGroup` metadata using `count`, drop `rate` to minimize crowding and confusion with the existing `rate` attribute of `TsdFrame`