### PR TITLE
Add gradient method for calculating derivatives

### DIFF
--- a/doc/user_guide/03_core_methods.md
+++ b/doc/user_guide/03_core_methods.md
@@ -263,6 +263,38 @@ plt.title("tsd.threshold(0.5)")
 plt.show()
 ```
 
+### `derivative`
+
+The `derivative` method of `Tsd`, `TsdFrame` and `TsdTensor` can be used to calculate the derivative of a time series with respect to time. It is a wrapper of [`numpy.gradient`](https://numpy.org/devdocs/reference/generated/numpy.gradient.html).
+
+
+```{code-cell} ipython3
+:tags: [hide-cell]
+tsd = nap.Tsd(
+    t=np.arange(0, 10, 0.1),
+    d=np.sin(np.arange(0, 10, 0.1)),
+)
+ep = nap.IntervalSet(start=[0, 6], end=[4, 10])
+```
+
+```{code-cell} ipython3
+derivative = tsd.derivative(ep=ep)
+```
+
+```{code-cell} ipython3
+:tags: [hide-input]
+plt.figure()
+plt.plot(tsd, label="tsd")
+plt.plot(derivative, 'o-', label="derivative")
+[plt.axvspan(s, e, alpha=0.2) for s, e in derivative.time_support.values]
+plt.axhline(0, linewidth=0.5, color='grey')
+plt.legend(loc="lower right")
+plt.xlabel("Time (s)")
+plt.title("tsd.derivative()")
+plt.show()
+```
+
+
 ### `to_trial_tensor`
 
 `Tsd`, `TsdFrame`, and `TsdTensor` all have the method `to_trial_tensor`, which creates a numpy array from an `IntervalSet` by slicing the time series. The resulting tensor has shape (shape of time series, number of trials, number of time points), where the first dimension(s) is dependent on the object. 

--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -638,8 +638,8 @@ class _BaseTsd(_Base, NDArrayOperatorsMixin, abc.ABC):
 
         return _initialize_tsd_output(self, new_d, time_index=new_t, time_support=ep)
 
-    def gradient(self, ep=None):
-        """Compute the gradient of the time series using numpy.gradient.
+    def derivative(self, ep=None):
+        """Computes the derivative of the time series with respect to time. Wraps numpy.gradient.
 
         Parameters
         ----------
@@ -649,7 +649,23 @@ class _BaseTsd(_Base, NDArrayOperatorsMixin, abc.ABC):
         Returns
         -------
         Tsd, TsdFrame or TsdTensor
-            The gradient of the time series.
+            The derivative of the time series.
+
+        Examples
+        --------
+        >>> import pynapple as nap
+        >>> import numpy as np
+        >>> tsd = nap.Tsd(t=np.arange(5), d=np.arange(0, 10, 2))
+        >>> tsd_derivative = tsd.derivative()
+        >>> tsd_derivative
+        Time (s)
+        ----------  --
+        0            2
+        1            2
+        2            2
+        3            2
+        4            2
+        dtype: float64, shape: (5,)
         """
         if ep is None:
             ep = self.time_support

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -1167,7 +1167,7 @@ class TestTsd:
         # Tsd
         data = np.sin(times)
         tsd = nap.Tsd(t=times, d=data)
-        expected_gradient = np.cos(times) # Derivative of sin(x) is cos(x)
+        expected_gradient = np.cos(times)  # Derivative of sin(x) is cos(x)
         gradient = tsd.gradient()
         np.testing.assert_allclose(gradient.values, expected_gradient, atol=1e-3)
 
@@ -1185,8 +1185,10 @@ class TestTsd:
         """
         times = np.arange(0, 100)
         data = np.tile(np.arange(0, 10), 10)
-        intervals = nap.IntervalSet(start=np.arange(0, 100, 10), end=np.arange(10, 110, 10))
-        expected_gradient = np.ones(len(times)) # Derivative is 1 across each interval
+        intervals = nap.IntervalSet(
+            start=np.arange(0, 100, 10), end=np.arange(10, 110, 10)
+        )
+        expected_gradient = np.ones(len(times))  # Derivative is 1 across each interval
 
         # With time support
         tsd = nap.Tsd(t=times, d=data, time_support=intervals)
@@ -1197,6 +1199,7 @@ class TestTsd:
         tsd = nap.Tsd(t=times, d=data)
         gradient = tsd.gradient(ep=intervals)
         assert np.all(gradient == expected_gradient)
+
 
 ####################################################
 # Test for tsdframe


### PR DESCRIPTION
Implements https://github.com/pynapple-org/pynapple/issues/389

## Summary

* Adds support for a new `derivative` method which wraps `np.gradient` with support for epochs and time index
* Adds unit tests with & without epochs

## Open questions
- [x] Do we want to call it something else like `grad` or `compute_derivatives` to distinguish from the original method?
- [x] Works with Tsd and TsdFrame along time axis - a little unclear to me if/how we should handle TsdTensor and whether we want to support `axis` or `edge_order` params 

## Example usage

Update: Added example to user docs:

<img width="616" alt="Screenshot 2025-05-04 at 11 31 55 PM" src="https://github.com/user-attachments/assets/10c6116f-66ae-4588-91a9-6aac3b40094c" />

Let me know what you think!