### PR TITLE
fixes npz loading of objects with metadata saved before v0.9

### DIFF
--- a/pynapple/core/base_class.py
+++ b/pynapple/core/base_class.py
@@ -739,5 +739,11 @@ class _Base(abc.ABC):
         if "_metadata" in file:  # load metadata if it exists
             if file["_metadata"]:  # check if metadata is not empty
                 m = file["_metadata"].item()
+                # check if first field is a dictionary, meaning it was saved from a pandas.DataFrame
+                if isinstance(next(iter(m.values())), dict):
+                    import pandas as pd
+
+                    m = pd.DataFrame.from_dict(m)
+
                 ts.set_info(m)
         return ts

--- a/pynapple/core/interval_set.py
+++ b/pynapple/core/interval_set.py
@@ -612,7 +612,10 @@ class IntervalSet(NDArrayOperatorsMixin, _MetadataMixin):
         ep = cls(start=file["start"], end=file["end"])
         if "_metadata" in file:  # load metadata if it exists
             if file["_metadata"]:  # check that metadata is not empty
-                metadata = pd.DataFrame.from_dict(file["_metadata"].item())
+                metadata = file["_metadata"].item()
+                # check if first field is a dictionary, meaning it was saved from a pandas.DataFrame
+                if isinstance(next(iter(metadata.values())), dict):
+                    metadata = pd.DataFrame.from_dict(metadata)
                 ep.set_info(metadata)
         return ep
 

--- a/pynapple/core/ts_group.py
+++ b/pynapple/core/ts_group.py
@@ -1642,6 +1642,9 @@ class TsGroup(UserDict, _MetadataMixin):
         if "_metadata" in file:  # load metadata if it exists
             if file["_metadata"]:  # check that metadata is not empty
                 metainfo = file["_metadata"].item()
+                # check if first field is a dictionary, meaning it was saved from a pandas.DataFrame
+                if isinstance(next(iter(metainfo.values())), dict):
+                    metainfo = pd.DataFrame.from_dict(metainfo)
                 tsgroup.set_info(metainfo)
 
         metainfo = {}


### PR DESCRIPTION
There was an issue with NPZ loading of objects with metadata saved before v0.9, where the pandas dataframe method `.to_dict()` was used to convert the metadata to a dictionary before saving. This method saves dictionary fields as another dictionary to preserve the row index. Therefore, this fix checks if the fields loaded metadata are also dictionaries, and then converts it to a pandas dataframe before instantiating the object to ensure that the metadata values are in an interpretable format