### PR TITLE
466 base docstrings

### DIFF
--- a/pynapple/core/base_class.py
+++ b/pynapple/core/base_class.py
@@ -14,16 +14,6 @@ from .time_index import TsIndex
 from .utils import check_filename, convert_to_numpy_array
 
 
-def add_base_docstring(base_func, sep="\n"):
-    base_doc = getattr(_Base, base_func).__doc__
-
-    def _decorator(func):
-        func.__doc__ = sep.join([base_doc, func.__doc__])
-        return func
-
-    return _decorator
-
-
 class _Base(abc.ABC):
     """
     Abstract base class for time series and timestamps objects.
@@ -196,27 +186,6 @@ class _Base(abc.ABC):
         -------
         out : Tsd, TsdFrame or TsdTensor
             Object with the new values
-
-        Examples
-        --------
-        In this example, the ts object will receive the closest values in time from tsd.
-
-        >>> import pynapple as nap
-        >>> import numpy as np
-        >>> t = np.unique(np.sort(np.random.randint(0, 1000, 100))) # random times
-        >>> ts = nap.Ts(t=t, time_units='s')
-        >>> tsd = nap.Tsd(t=np.arange(0,1000), d=np.random.rand(1000), time_units='s')
-        >>> ep = nap.IntervalSet(start = 0, end = 500, time_units = 's')
-
-        The variable ts is a timestamp object.
-        The tsd object containing the values, for example the tracking data, and the epoch to restrict the operation.
-
-        >>> newts = ts.value_from(tsd, ep, mode='closest')
-
-        newts is the same size as ts restrict to ep.
-
-        >>> print(len(ts.restrict(ep)), len(newts))
-            52 52
         """
         if not isinstance(data, _Base) and not hasattr(data, "values"):
             raise TypeError(

--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -44,9 +44,9 @@ from .utils import (
     _get_terminal_size,
     _split_tsd,
     _TsdFrameSliceHelper,
+    add_docstring_to,
     convert_to_array,
     is_array_like,
-    add_docstring_to,
 )
 
 
@@ -179,10 +179,10 @@ class _BaseTsd(_Base, NDArrayOperatorsMixin, abc.ABC):
                 )
             self.values = d
 
-        assert len(self.index) == len(self.values), (
-            "Length of values {} does not match length of index {}".format(
-                len(self.values), len(self.index)
-            )
+        assert len(self.index) == len(
+            self.values
+        ), "Length of values {} does not match length of index {}".format(
+            len(self.values), len(self.index)
         )
 
         if isinstance(time_support, IntervalSet) and len(self.index):
@@ -1264,9 +1264,9 @@ class TsdFrame(_BaseTsd, _MetadataMixin):
         if c is None or len(c) != self.values.shape[1]:
             c = np.arange(self.values.shape[1], dtype="int")
         else:
-            assert len(c) == self.values.shape[1], (
-                "Number of columns should match the second dimension of d"
-            )
+            assert (
+                len(c) == self.values.shape[1]
+            ), "Number of columns should match the second dimension of d"
 
         self.columns = pd.Index(c)
         self.nap_class = self.__class__.__name__

--- a/pynapple/core/utils.py
+++ b/pynapple/core/utils.py
@@ -148,11 +148,7 @@ def is_array_like(obj):
     # not_tsd_type = not isinstance(obj, _AbstractTsd)
 
     return (
-        has_shape
-        and has_dtype
-        and has_ndim
-        and is_indexable
-        and is_iterable
+        has_shape and has_dtype and has_ndim and is_indexable and is_iterable
         # and not_tsd_type
     )
 
@@ -469,3 +465,13 @@ def _convert_iter_to_str(array):
             )
         else:
             return array.astype(str)
+
+
+def add_docstring_to(_class, base_func, sep="\n"):
+    base_doc = getattr(_class, base_func).__doc__
+
+    def _decorator(func):
+        func.__doc__ = sep.join([base_doc, func.__doc__])
+        return func
+
+    return _decorator

--- a/pynapple/core/utils.py
+++ b/pynapple/core/utils.py
@@ -148,7 +148,11 @@ def is_array_like(obj):
     # not_tsd_type = not isinstance(obj, _AbstractTsd)
 
     return (
-        has_shape and has_dtype and has_ndim and is_indexable and is_iterable
+        has_shape
+        and has_dtype
+        and has_ndim
+        and is_indexable
+        and is_iterable
         # and not_tsd_type
     )
 


### PR DESCRIPTION
Firstly, adds a general decorator to add docstrings to methods.

Then uses it to write correct docstrings for `_Base` methods:
- `value_from` [DONE]
- `time_diff` [DONE]
- `restrict`
- `count`
- `get_slice`