### PR TITLE
Add `detect_oscillatory_events` method

### DIFF
--- a/pynapple/process/filtering.py
+++ b/pynapple/process/filtering.py
@@ -548,20 +548,20 @@ def detect_oscillatory_events(
     window = np.ones(wsize) / wsize
 
     nSS = filtfilt(window, 1, squared_signal)
-    nSS = (nSS - np.mean(nSS))/np.std(nSS)
-    nSS = nap.Tsd(t = signal.index.values, d=nSS, time_support=epoch)
+    nSS = (nSS - np.mean(nSS)) / np.std(nSS)
+    nSS = nap.Tsd(t=signal.index.values, d=nSS, time_support=epoch)
 
     # Detect oscillation periods by thresholding normalized signal
-    nSS2 = nSS.threshold(thresh_band[0], method='above')
-    nSS3 = nSS2.threshold(thresh_band[1], method='below')
+    nSS2 = nSS.threshold(thresh_band[0], method="above")
+    nSS3 = nSS2.threshold(thresh_band[1], method="below")
 
     # Exclude oscillation where min_duration < length < max_duration
     osc_ep = nSS3.time_support
-    osc_ep = osc_ep.drop_short_intervals(duration_band[0], time_units = 's')
-    osc_ep = osc_ep.drop_long_intervals(duration_band[1], time_units = 's')
+    osc_ep = osc_ep.drop_short_intervals(duration_band[0], time_units="s")
+    osc_ep = osc_ep.drop_long_intervals(duration_band[1], time_units="s")
 
     # Merge if inter-oscillation period is too short
-    osc_ep = osc_ep.merge_close_intervals(min_inter_duration, time_units = 's')
+    osc_ep = osc_ep.merge_close_intervals(min_inter_duration, time_units="s")
 
     # Compute power, amplitude, and peak_time for each interval
     powers = []

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -526,13 +526,14 @@ def test_get_filter_frequency_response_error():
 
 
 @pytest.mark.parametrize(
-    "freq_band, thresh_band, start, end",
+    "freq_band, thresh_band, num_events, start, end",
     [
-        ((10, 30), (1, 10), 0, 2),
-        ((40, 60), (1, 10), 3, 5),
+        ((10, 30), (1, 10), 1, 0, 2),
+        ((40, 60), (1, 10), 1, 3, 5),
+        ((100, 150), (1, 10), 0, None, None),
     ],
 )
-def test_detect_oscillatory_events(freq_band, thresh_band, start, end):
+def test_detect_oscillatory_events(freq_band, thresh_band, num_events, start, end):
     fs = 1000
     duration = 5
     min_dur = 0.1
@@ -558,18 +559,19 @@ def test_detect_oscillatory_events(freq_band, thresh_band, start, end):
         ts, epoch, freq_band, thresh_band, (min_dur, max_dur), min_inter
     )
 
-    assert len(osc_ep) == 1  # Only one event in given freq_band
+    assert len(osc_ep) == num_events  # Only one event in given freq_band
 
-    # Start and end should be close to actuals +/- a small amount
-    detected_start = osc_ep.start[0]
-    detected_end = osc_ep.end[0]
-    assert np.isclose(start, detected_start, atol=0.05)
-    assert np.isclose(end, detected_end, atol=0.05)
+    if num_events > 0:
+        # Start and end should be close to actuals +/- a small amount
+        detected_start = osc_ep.start[0]
+        detected_end = osc_ep.end[0]
+        assert np.isclose(start, detected_start, atol=0.05)
+        assert np.isclose(end, detected_end, atol=0.05)
 
-    # Check we store power, amplitude, and peak_time
-    for key in ["power", "amplitude", "peak_time"]:
-        assert key in osc_ep._metadata
+        # Check we store power, amplitude, and peak_time
+        for key in ["power", "amplitude", "peak_time"]:
+            assert key in osc_ep._metadata
 
-    # Check peak_time is within the interval
-    peak_time = osc_ep._metadata["peak_time"][0]
-    assert start <= peak_time <= end
+        # Check peak_time is within the interval
+        peak_time = osc_ep._metadata["peak_time"][0]
+        assert start <= peak_time <= end

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -481,7 +481,7 @@ def test_compare_sinc_kernel():
 
     ikernel = nap.process.filtering._compute_spectral_inversion(kernel)
     ikernel2 = kernel2 * -1.0
-    ikernel2[len(ikernel2) // 2] = 1.0 + ikernel2[len(kernel2) // 2]
+    ikernel2[len(kernel2) // 2] = 1.0 + ikernel2[len(kernel2) // 2]
     np.testing.assert_allclose(ikernel, ikernel2)
 
 
@@ -523,3 +523,52 @@ def test_get_filter_frequency_response_error():
         ValueError, match="Unrecognized filter mode. Choose either 'butter' or 'sinc'"
     ):
         nap.get_filter_frequency_response(250, 1000, "lowpass", "a", 4, 0.02)
+
+
+@pytest.mark.parametrize(
+    "freq_band, thresh_band, start, end",
+    [
+        ((10, 30), (1, 10), 0, 2),
+        ((40, 60), (1, 10), 3, 5),
+    ],
+)
+def test_detect_oscillatory_events(freq_band, thresh_band, start, end):
+    fs = 1000
+    duration = 5
+    min_dur = 0.1
+    max_dur = 2
+    min_inter = 0.02
+
+    t = np.linspace(0, duration, int(fs * duration), endpoint=False)
+    signal = np.zeros_like(t)
+
+    # 25 Hz oscillation from 0-2s
+    freq_1 = 25
+    mask1 = (t >= 0) & (t < 2)
+    signal[mask1] = np.sin(2 * np.pi * freq_1 * t[mask1])
+
+    # 50 Hz oscillation from 3-5s
+    freq_2 = 50
+    mask2 = (t >= 3) & (t < 5)
+    signal[mask2] = np.sin(2 * np.pi * freq_2 * t[mask2])
+
+    ts = nap.Tsd(t=t, d=signal)
+    epoch = nap.IntervalSet(start=0, end=duration)
+    osc_ep = nap.filtering.detect_oscillatory_events(
+        ts, epoch, freq_band, thresh_band, (min_dur, max_dur), min_inter)
+
+    assert len(osc_ep) == 1  # Only one event in given freq_band
+
+    # Start and end should be close to actuals +/- a small amount
+    detected_start = osc_ep.start[0]
+    detected_end = osc_ep.end[0]
+    assert np.isclose(start, detected_start, atol=0.05)
+    assert np.isclose(end, detected_end, atol=0.05)
+
+    # Check we store power, amplitude, and peak_time
+    for key in ["power", "amplitude", "peak_time"]:
+        assert key in osc_ep._metadata
+
+    # Check peak_time is within the interval
+    peak_time = osc_ep._metadata["peak_time"][0]
+    assert start <= peak_time <= end

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -481,7 +481,7 @@ def test_compare_sinc_kernel():
 
     ikernel = nap.process.filtering._compute_spectral_inversion(kernel)
     ikernel2 = kernel2 * -1.0
-    ikernel2[len(kernel2) // 2] = 1.0 + ikernel2[len(kernel2) // 2]
+    ikernel2[len(ikernel2) // 2] = 1.0 + ikernel2[len(kernel2) // 2]
     np.testing.assert_allclose(ikernel, ikernel2)
 
 
@@ -555,7 +555,8 @@ def test_detect_oscillatory_events(freq_band, thresh_band, start, end):
     ts = nap.Tsd(t=t, d=signal)
     epoch = nap.IntervalSet(start=0, end=duration)
     osc_ep = nap.filtering.detect_oscillatory_events(
-        ts, epoch, freq_band, thresh_band, (min_dur, max_dur), min_inter)
+        ts, epoch, freq_band, thresh_band, (min_dur, max_dur), min_inter
+    )
 
     assert len(osc_ep) == 1  # Only one event in given freq_band
 


### PR DESCRIPTION
### Summary
Adds a new method `detect_oscillatory_events` to the `filtering` module that allows for detection of ripple-like intervals in signals. Based on [this EEG processing example](https://github.com/PeyracheLab/pynacollada/blob/main/pynacollada/eeg_processing/eeg_processing.py). 

### Example
<img width="600" height="224" alt="Screenshot 2025-08-02 at 2 38 15 PM" src="https://github.com/user-attachments/assets/7080d91e-04b3-4f3b-96b9-e3616f20fec8" />

## Todo
* Will follow-up with a new user guide as discussed demonstrating usage on real data

### Open questions
* Still having trouble getting the sphinx docs to consistently compile - believe this is a local dev issue.
* We discussed using `apply_bandpass` instead of `filtfilt` but I think as written, both may be necessary unless we think it's ok to skip the smoothing step—or could use `Tsd.smooth` here?
* Does the testing approach make sense / seem adequate here? 
