### PR TITLE
Fix TsdFrame `repr` for boolean data type

### DIFF
--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -1535,7 +1535,7 @@ class TsdFrame(_BaseTsd, _MetadataMixin):
                             np.hstack(
                                 (
                                     self.index[0:n_rows, None],
-                                    np.round(self.values[0:n_rows, 0:max_cols], 5),
+                                    self.values[0:n_rows, 0:max_cols],
                                     ends,
                                 ),
                                 dtype=object,
@@ -1543,7 +1543,7 @@ class TsdFrame(_BaseTsd, _MetadataMixin):
                             np.array(
                                 [
                                     ["..."]
-                                    + ["..."] * np.minimum(max_cols, self.shape[1])
+                                    + [None] * np.minimum(max_cols, self.shape[1])
                                     + end
                                 ],
                                 dtype=object,
@@ -1551,7 +1551,7 @@ class TsdFrame(_BaseTsd, _MetadataMixin):
                             np.hstack(
                                 (
                                     self.index[-n_rows:, None],
-                                    np.round(self.values[-n_rows:, 0:max_cols], 5),
+                                    self.values[-n_rows:, 0:max_cols],
                                     ends,
                                 ),
                                 dtype=object,
@@ -1563,7 +1563,7 @@ class TsdFrame(_BaseTsd, _MetadataMixin):
                     table = np.hstack(
                         (
                             self.index[:, None],
-                            np.round(self.values[:, 0:max_cols], 5),
+                            self.values[:, 0:max_cols],
                             ends,
                         ),
                         dtype=object,


### PR DESCRIPTION
TsdFrame `repr` was breaking if the data type was a boolean, since it was trying to apply `np.round` to each value. This PR removes `np.round` so that it is compatible with boolean (and non-float) data types. It also removes the `"..."` string that was appended to value columns when rows are skipped so that tabulate will use it's default rounding for columns of floats (this is consistent with Tsd)