### PR TITLE
Fix indexing of a TsdFrame with a Tsd/TsdFrame

### DIFF
--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -1705,15 +1705,18 @@ class TsdFrame(_BaseTsd, _MetadataMixin):
     def __getitem__(self, key, *args, **kwargs):
         if isinstance(key, tuple):
             key = tuple(k.values if hasattr(k, "values") else k for k in key)
-        if isinstance(key, Tsd):
+        if isinstance(key, (Tsd, TsdFrame)):
             try:
                 assert np.issubdtype(key.dtype, np.bool_)
             except AssertionError:
                 raise ValueError(
-                    "When indexing with a Tsd, it must contain boolean values"
+                    "When indexing with a Tsd or TsdFrame, it must contain boolean values"
                 )
-            key = key.d
-        elif isinstance(key, str):
+            if isinstance(key, TsdFrame):
+                return self.values.__getitem__(key.d)
+            else:
+                key = key.d
+        if isinstance(key, str):
             if key in self.columns:
                 with warnings.catch_warnings():
                     # ignore deprecated warning for loc

--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -1535,7 +1535,7 @@ class TsdFrame(_BaseTsd, _MetadataMixin):
                             np.hstack(
                                 (
                                     self.index[0:n_rows, None],
-                                    np.round(self.values[0:n_rows, 0:max_cols], 5),
+                                    self.values[0:n_rows, 0:max_cols],
                                     ends,
                                 ),
                                 dtype=object,
@@ -1543,7 +1543,7 @@ class TsdFrame(_BaseTsd, _MetadataMixin):
                             np.array(
                                 [
                                     ["..."]
-                                    + ["..."] * np.minimum(max_cols, self.shape[1])
+                                    + [None] * np.minimum(max_cols, self.shape[1])
                                     + end
                                 ],
                                 dtype=object,
@@ -1551,7 +1551,7 @@ class TsdFrame(_BaseTsd, _MetadataMixin):
                             np.hstack(
                                 (
                                     self.index[-n_rows:, None],
-                                    np.round(self.values[-n_rows:, 0:max_cols], 5),
+                                    self.values[-n_rows:, 0:max_cols],
                                     ends,
                                 ),
                                 dtype=object,
@@ -1563,7 +1563,7 @@ class TsdFrame(_BaseTsd, _MetadataMixin):
                     table = np.hstack(
                         (
                             self.index[:, None],
-                            np.round(self.values[:, 0:max_cols], 5),
+                            self.values[:, 0:max_cols],
                             ends,
                         ),
                         dtype=object,

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -1604,6 +1604,27 @@ class TestTsdFrame:
                         output, tsdframe.values[row, col]
                     )
 
+    def test_tsd_indexing(self, tsdframe):
+        tsd_index = tsdframe[:, 0] > 0
+        output = tsdframe[tsd_index]
+        np.testing.assert_array_almost_equal(
+            output.values, tsdframe.values[tsd_index.values]
+        )
+        assert isinstance(output, nap.TsdFrame)
+
+        with pytest.raises(ValueError, match="must contain boolean values"):
+            tsdframe[tsd_index + 1]
+
+        tsdframe_index = tsdframe > 0
+        output = tsdframe[tsdframe_index]
+        np.testing.assert_array_almost_equal(
+            output, tsdframe.values[tsdframe_index.values]
+        )
+        assert isinstance(output, np.ndarray)
+
+        with pytest.raises(ValueError, match="must contain boolean values"):
+            tsdframe[tsdframe_index + 1]
+
     @pytest.mark.parametrize("index", [0, [0, 2]])
     def test_str_indexing(self, tsdframe, index):
         columns = tsdframe.columns


### PR DESCRIPTION
Previously, indexing with a Tsd object was not working correctly - it was in an "if" statement that could never run with the indexing logic. Now, the if-statement terminates such that the modified key can be used by the main indexing logic.

I also added a case to allow indexing by a boolean TsdFrame, which is consistent with numpy indexing behavior.

I added a new test for these cases