### PR TITLE
489 refactor mutual information

### DIFF
--- a/pynapple/process/__init__.py
+++ b/pynapple/process/__init__.py
@@ -29,6 +29,7 @@ from .spectrum import (
     compute_power_spectral_density,
 )
 from .tuning_curves import (
+    compute_mutual_information,
     compute_1d_mutual_info,
     compute_1d_tuning_curves,
     compute_1d_tuning_curves_continuous,


### PR DESCRIPTION
This combines:
- `compute_1d_mutual_info`
- `compute_2d_mutual_info`

into a generalised n-dimensional `compute_mutual_information`, which takes as only input the tuning curves as an xarray.DataArray (the new output of compute_tuning_curves) and returns an xarray.DataArray with dimensions "unit" (N) and "bits" (always 2, bits/spike and bits/sec).

Since occupancy is now an attribute of the tuning curves, `compute_mutual_information` uses that directly, and no other arguments need to be passed.

The old functions (and tests) are still available but they throw a DeprecationWarning.