### PR TITLE
Update Python version to 3.12 in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.x
+        python-version: 3.12
 
     - name: Build package
       run: |


### PR DESCRIPTION
This pull request makes a minor update to the deployment workflow by specifying Python 3.12 as the version to use during setup. This prevents an error with numba who does not support python=3.14 yet.