### PR TITLE
Update `detect_oscillatory_events`

### DIFF
--- a/doc/examples/tutorial_ripple_detection.md
+++ b/doc/examples/tutorial_ripple_detection.md
@@ -62,7 +62,7 @@ lfp.rate
 
 Frequency filtering
 -------------------
-To look for ripples we will only keep frequencies within 150 to 250Hz:
+To look for ripples we will only keep frequencies within 120 to 250Hz:
 ```{code-cell} ipython3
 filtered_lfp = nap.apply_bandpass_filter(lfp, cutoff=(120, 250), fs=lfp.rate)
 filtered_lfp
@@ -77,7 +77,7 @@ plt.plot(filtered_lfp.restrict(segment), label="filtered LFP")
 plt.xlabel("time (s)")
 plt.ylabel("amplitude (a.u.)")
 plt.legend()
-plt.title("nap.apply_bandpass_filter(lfp, cutoff=(120, 150), fs=lfp.rate")
+plt.title("nap.apply_bandpass_filter(lfp, cutoff=(120, 150), fs=lfp.rate)")
 plt.tight_layout();
 ```
 
@@ -85,7 +85,7 @@ Hilbert transform: computing the envelope
 -----------------------------------------
 Now, we will apply the Hilbert transform to the filtered LFP and take its absolute value 
 to extract the amplitude envelope, which reflects ripple strength over time. 
-Pynapple provides [`compute_hilbert_envelope`](pynapple.process.signal.compute_hilbert_envelope]:
+Pynapple provides [`compute_hilbert_envelope`](pynapple.process.signal.compute_hilbert_envelope):
 
 ```{code-cell} ipython3
 envelope = nap.compute_hilbert_envelope(filtered_lfp)
@@ -113,7 +113,9 @@ Smooth and Z-score
 We will then smooth and z-score the envelope:
 
 ```{code-cell} ipython3
-smoothed = envelope.smooth(0.005)
+smoothing_bins = 10
+window = np.ones(smoothing_bins) / smoothing_bins
+smoothed = envelope.convolve(window)
 zscored_smoothed = (smoothed - smoothed.mean()) / smoothed.std()
 ```
 
@@ -135,17 +137,58 @@ plt.tight_layout();
 Ripple detection
 ----------------
 We detect ripple events by thresholding the z-scored smoothed signal with a threshold of 3 standard deviations.
-We further filter detected events to keep only those between 30 ms and 300 ms in duration, typical for hippocampal ripples. 
+We further filter detected events to keep only those between 30ms and 300ms in duration, typical for hippocampal ripples. 
+We lastly merge events that are closer to each other than 20ms, as they are likely to be the same ripple.
 ```{code-cell} ipython3
 threshold = 3
 ripple_events = zscored_smoothed.threshold(threshold, method="above")
 ripple_epochs = ripple_events.time_support
 ripple_epochs = ripple_epochs.drop_short_intervals(0.03, time_units="s")
-ripple_epochs = ripple_epochs.drop_long_intervals(0.2, time_units="s")    
+ripple_epochs = ripple_epochs.drop_long_intervals(0.3, time_units="s")    
+ripple_epochs = ripple_epochs.merge_close_intervals(0.02, time_units="s")
 ripple_epochs.intersect(segment)
 ```
 
 Finally, we can plot the detected ripple events on top of the filtered LFP signal for visual confirmation:
+```{code-cell} ipython3
+:tags: [hide-input]
+fig = plt.figure(figsize=(10, 5))
+plt.plot(zscored_smoothed.restrict(segment), label="z-scored & smoothed")
+for start, end in ripple_epochs.intersect(segment).values:
+    plt.axvspan(start, end, alpha=0.3, color="red")
+plt.axhline(threshold, color="black", linestyle="--")
+plt.ylabel("amplitude (a.u.)")
+plt.xlabel("time (s)")
+plt.tight_layout();
+```
+
+
+Using `detect_oscillatory_events`
+=================================
+
+For your convenience, we put the entire process into a single 
+function called [`detect_oscillatory_events`](pynapple.process.signal.detect_oscillatory_events).
+
+To get it to work nicely, you will have to the tune the following detection parameters:
+- frequency band: the band of frequencies you are interested in
+- threshold band: minimum and maximum thresholds to apply to the z-scored envelope of the squared signal
+- duration band: minimum and maximum duration of the events
+- minimum interval between events
+```{code-cell} ipython3
+ripple_epochs = nap.detect_oscillatory_events(
+    data=lfp,
+    epochs=lfp.time_support,
+    frequency_band=(120, 250),
+    threshold_band=(3, 15),
+    duration_band=(0.03, 0.3),
+    min_interval=0.02,
+    sliding_window_size=smoothing_bins
+)
+ripple_epochs.intersect(segment)
+```
+
+You can see that this gives the same result as before:
+
 ```{code-cell} ipython3
 :tags: [hide-input]
 fig = plt.figure(figsize=(10, 5))

--- a/doc/user_guide/13_phases_and_envelopes.md
+++ b/doc/user_guide/13_phases_and_envelopes.md
@@ -190,28 +190,19 @@ at high frequencies.
 Pynapple provides the [`detect_oscillatory_events`](pynapple.process.signal.detect_oscillatory_events)
 exactly for such a goal.
 
-To get it to work nicely, you will have the tune the following detection parameters:
-- frequency band: the band of frequencies you are interested in.
-- threshold band: minimum and maximum thresholds to apply to the z-scored envelope of the squared signal.
-- minimum and maximum duration of the events
+To get it to work nicely, you will have to the tune the following detection parameters:
+- frequency band: the band of frequencies you are interested in
+- threshold band: minimum and maximum thresholds to apply to the z-scored envelope of the squared signal
+- duration band: minimum and maximum duration of the events
 - minimum interval between events
 ```{code-cell} ipython3
-# Define detection parameters
-freq_band = (35, 45)   # Gamma band
-thres_band = (1, 5)    # Thresholds for normalized squared envelope
-min_dur = 0.4          # Minimum event duration
-max_dur = 0.6          # Max event duration
-min_inter = 0.05       # Minimum interval between events
-epoch = signal.time_support
-
-# Detect oscillatory events
 events = nap.detect_oscillatory_events(
-    signal,
-    epoch,
-    freq_band,
-    thres_band,
-    (min_dur, max_dur),
-    min_inter,
+    data=signal,
+    epochs=signal.time_support,
+    frequency_band=(35, 45),
+    threshold_band=(1,5),
+    duration_band=(0.4,0.6),
+    min_interval=0.05,
 )
 events
 ```

--- a/pynapple/process/signal.py
+++ b/pynapple/process/signal.py
@@ -2,6 +2,8 @@
 Functions to compute phases and envelopes
 """
 
+import numbers
+
 import numpy as np
 
 import pynapple as nap
@@ -265,7 +267,7 @@ def detect_oscillatory_events(
     freq_band : tuple
         The (low, high) frequency to bandpass the signal
     thresh_band : tuple
-        The (min, max) value for thresholding the normalized squared signal after filtering
+        The (min, max) value for thresholding the normalized envelope of the signal after filtering
     duration_band : tuple
         The (min, max) duration of an event in second
     min_inter_duration : float
@@ -283,20 +285,60 @@ def detect_oscillatory_events(
     """
     import warnings
 
-    from scipy.signal import filtfilt
+    if not isinstance(data, nap.Tsd):
+        raise TypeError(f"`data` must be `Tsd`, got {type(data)}")
+
+    if not isinstance(epoch, nap.IntervalSet):
+        raise TypeError(f"`epoch` must be `IntervalSet`, got {type(epoch)}")
+
+    def _check_tuple(name, val):
+        if not isinstance(val, tuple):
+            raise TypeError(f"`{name}` must be a tuple, got {type(val)}")
+        if len(val) != 2:
+            raise ValueError(f"`{name}` must have length 2, got {len(val)}")
+        if not all(isinstance(x, numbers.Real) for x in val):
+            raise TypeError(f"`{name}` must contain numeric values")
+        if val[0] >= val[1]:
+            raise ValueError(f"`{name}` must be (min, max) with min < max")
+
+    _check_tuple("freq_band", freq_band)
+    _check_tuple("thresh_band", thresh_band)
+    _check_tuple("duration_band", duration_band)
+
+    if not isinstance(min_inter_duration, numbers.Real):
+        raise TypeError("`min_inter_duration` must be a number")
+    if min_inter_duration < 0:
+        raise ValueError("`min_inter_duration` must be >= 0")
+
+    if fs is not None:
+        if not isinstance(fs, numbers.Real):
+            raise TypeError("`fs` must be a number or None")
+        if fs <= 0:
+            raise ValueError("`fs` must be > 0")
+    else:
+        fs = data.rate
+
+    if not isinstance(wsize, int):
+        raise TypeError("`wsize` must be an integer")
+    if wsize <= 0:
+        raise ValueError("`wsize` must be > 0")
+    if wsize % 2 == 0:
+        raise ValueError("`wsize` should be odd for symmetric smoothing")
 
     data = data.restrict(epoch)
 
-    if fs is None:
-        fs = data.rate
+    # Frequency filter
+    filtered = nap.apply_bandpass_filter(data, freq_band, fs)
 
-    signal = nap.apply_bandpass_filter(data, freq_band, fs)
-    squared_signal = np.square(signal.values)
+    # Compute envelope
+    envelope = nap.compute_hilbert_envelope(filtered)
+
+    # Smooth
     window = np.ones(wsize) / wsize
+    smoothed = envelope.convolve(window)
 
-    nSS = filtfilt(window, 1, squared_signal)
-    nSS = (nSS - np.mean(nSS)) / np.std(nSS)
-    nSS = nap.Tsd(t=signal.index.values, d=nSS, time_support=epoch)
+    # Z-score
+    zscored_smoothed = (smoothed - smoothed.mean()) / smoothed.std()
 
     # Detect oscillation periods by thresholding normalized signal
     with warnings.catch_warnings():
@@ -305,11 +347,15 @@ def detect_oscillatory_events(
             message="Some epochs have no duration",
             category=UserWarning,
         )
-        nSS2 = nSS.threshold(thresh_band[0], method="above")
-        nSS3 = nSS2.threshold(thresh_band[1], method="below")
+        zscored_smoothed_above = zscored_smoothed.threshold(
+            thresh_band[0], method="above"
+        )
+        zscored_smoothed_thresholded = zscored_smoothed_above.threshold(
+            thresh_band[1], method="below"
+        )
 
-    # Exclude oscillation where min_duration < length < max_duration
-    osc_ep = nSS3.time_support
+    # Exclude oscillations where min_duration < length < max_duration
+    osc_ep = zscored_smoothed_thresholded.time_support
     osc_ep = osc_ep.drop_short_intervals(duration_band[0], time_units="s")
     osc_ep = osc_ep.drop_long_intervals(duration_band[1], time_units="s")
 
@@ -322,17 +368,20 @@ def detect_oscillatory_events(
     peak_times = []
 
     for s, e in osc_ep.values:
-        seg = signal.get(s, e)
+        seg = envelope.get(s, e)
         if len(seg) == 0:
             powers.append(np.nan)
             amplitudes.append(np.nan)
             peak_times.append(np.nan)
             continue
-        power = np.mean(np.square(seg))
-        power_db = 10 * np.log10(power)
-        amplitude = np.max(np.abs(seg.values))
-        peak_idx = np.argmax(np.abs(seg.values))
+
+        power = np.mean(seg.values**2)
+        power_db = 10 * np.log10(power) if power > 0 else np.nan
+
+        amplitude = np.max(seg.values)
+        peak_idx = np.argmax(seg.values)
         peak_time = seg.index.values[peak_idx]
+
         powers.append(power_db)
         amplitudes.append(amplitude)
         peak_times.append(peak_time)

--- a/pynapple/process/signal.py
+++ b/pynapple/process/signal.py
@@ -247,35 +247,38 @@ def compute_hilbert_phase(data):
 
 def detect_oscillatory_events(
     data,
-    epoch,
-    freq_band,
-    thresh_band,
+    epochs,
+    frequency_band,
+    threshold_band,
     duration_band,
-    min_inter_duration,
+    min_interval,
     fs=None,
-    wsize=51,
+    sliding_window_size=51,
 ):
     """
-    Simple helper for detecting oscillatory events (e.g. ripples, spindles)
+    Function for detecting oscillatory events such as ripples, spindles, and more.
 
     Parameters
     ----------
     data : Tsd
-        1-dimensional time series
-    epoch : IntervalSet
-        The epoch for restricting the detection
-    freq_band : tuple
-        The (low, high) frequency to bandpass the signal
-    thresh_band : tuple
-        The (min, max) value for thresholding the normalized envelope of the signal after filtering
+        One-dimensional time series.
+    epochs : IntervalSet
+        The epochs for restricting the detection.
+    frequency_band : tuple
+        The lower and upper frequency to bandpass filter the signal.
+    threshold_band : tuple
+        The lower and upper threshold applied to the normalized envelope of the
+        filtered signal.
     duration_band : tuple
-        The (min, max) duration of an event in second
-    min_inter_duration : float
-        The minimum duration between two events otherwise they are merged (in seconds)
+        The minimal and maximal duration of an event (in seconds).
+    min_interval : float
+        The minimum duration between two events (in seconds).
+        If shorter, the two events are merged.
     fs : float, optional
-        The sampling frequency of the signal in Hz. If not provided, it will be inferred from the time axis of the data.
-    wsize : int, optional
-        The size of the window for digital filtering
+        The sampling frequency of the signal in Hz.
+        If not provided, it will be inferred from the time axis of the data.
+    sliding_window_size : int, optional
+        The size of the smoothing window.
 
     Returns
     -------
@@ -288,8 +291,8 @@ def detect_oscillatory_events(
     if not isinstance(data, nap.Tsd):
         raise TypeError(f"`data` must be `Tsd`, got {type(data)}")
 
-    if not isinstance(epoch, nap.IntervalSet):
-        raise TypeError(f"`epoch` must be `IntervalSet`, got {type(epoch)}")
+    if not isinstance(epochs, nap.IntervalSet):
+        raise TypeError(f"`epochs` must be `IntervalSet`, got {type(epochs)}")
 
     def _check_tuple(name, val):
         if not isinstance(val, tuple):
@@ -301,14 +304,14 @@ def detect_oscillatory_events(
         if val[0] >= val[1]:
             raise ValueError(f"`{name}` must be (min, max) with min < max")
 
-    _check_tuple("freq_band", freq_band)
-    _check_tuple("thresh_band", thresh_band)
+    _check_tuple("frequency_band", frequency_band)
+    _check_tuple("threshold_band", threshold_band)
     _check_tuple("duration_band", duration_band)
 
-    if not isinstance(min_inter_duration, numbers.Real):
-        raise TypeError("`min_inter_duration` must be a number")
-    if min_inter_duration < 0:
-        raise ValueError("`min_inter_duration` must be >= 0")
+    if not isinstance(min_interval, numbers.Real):
+        raise TypeError("`min_interval` must be a number")
+    if min_interval < 0:
+        raise ValueError("`min_interval` must be >= 0")
 
     if fs is not None:
         if not isinstance(fs, numbers.Real):
@@ -318,23 +321,21 @@ def detect_oscillatory_events(
     else:
         fs = data.rate
 
-    if not isinstance(wsize, int):
-        raise TypeError("`wsize` must be an integer")
-    if wsize <= 0:
-        raise ValueError("`wsize` must be > 0")
-    if wsize % 2 == 0:
-        raise ValueError("`wsize` should be odd for symmetric smoothing")
+    if not isinstance(sliding_window_size, int):
+        raise TypeError("`sliding_window_size` must be an integer")
+    if sliding_window_size <= 0:
+        raise ValueError("`sliding_window_size` must be > 0")
 
-    data = data.restrict(epoch)
+    data = data.restrict(epochs)
 
     # Frequency filter
-    filtered = nap.apply_bandpass_filter(data, freq_band, fs)
+    filtered = nap.apply_bandpass_filter(data, frequency_band, fs)
 
     # Compute envelope
     envelope = nap.compute_hilbert_envelope(filtered)
 
     # Smooth
-    window = np.ones(wsize) / wsize
+    window = np.ones(sliding_window_size) / sliding_window_size
     smoothed = envelope.convolve(window)
 
     # Z-score
@@ -348,10 +349,10 @@ def detect_oscillatory_events(
             category=UserWarning,
         )
         zscored_smoothed_above = zscored_smoothed.threshold(
-            thresh_band[0], method="above"
+            threshold_band[0], method="above"
         )
         zscored_smoothed_thresholded = zscored_smoothed_above.threshold(
-            thresh_band[1], method="below"
+            threshold_band[1], method="below"
         )
 
     # Exclude oscillations where min_duration < length < max_duration
@@ -360,7 +361,7 @@ def detect_oscillatory_events(
     osc_ep = osc_ep.drop_long_intervals(duration_band[1], time_units="s")
 
     # Merge if inter-oscillation period is too short
-    osc_ep = osc_ep.merge_close_intervals(min_inter_duration, time_units="s")
+    osc_ep = osc_ep.merge_close_intervals(min_interval, time_units="s")
 
     # Compute power, amplitude, and peak_time for each interval
     powers = []

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -24,45 +24,49 @@ import pynapple as nap
             pytest.raises(TypeError, match="`data` must be `Tsd`, got <class 'str'>"),
         ),
         (
-            "epoch",
+            "epochs",
             None,
             pytest.raises(
                 TypeError,
-                match="`epoch` must be `IntervalSet`, got <class 'NoneType'>",
+                match="`epochs` must be `IntervalSet`, got <class 'NoneType'>",
             ),
         ),
         (
-            "epoch",
+            "epochs",
             "invalid_epoch",
             pytest.raises(
                 TypeError,
-                match="`epoch` must be `IntervalSet`, got <class 'str'>",
+                match="`epochs` must be `IntervalSet`, got <class 'str'>",
             ),
         ),
         (
-            "freq_band",
+            "frequency_band",
             (10, "not_a_number"),
-            pytest.raises(TypeError, match="`freq_band` must contain numeric values"),
-        ),
-        (
-            "freq_band",
-            (10, 5),
             pytest.raises(
-                ValueError,
-                match=re.escape("`freq_band` must be (min, max) with min < max"),
+                TypeError, match="`frequency_band` must contain numeric values"
             ),
         ),
         (
-            "thresh_band",
-            (1, "not_a_number"),
-            pytest.raises(TypeError, match="`thresh_band` must contain numeric values"),
-        ),
-        (
-            "thresh_band",
+            "frequency_band",
             (10, 5),
             pytest.raises(
                 ValueError,
-                match=re.escape("`thresh_band` must be (min, max) with min < max"),
+                match=re.escape("`frequency_band` must be (min, max) with min < max"),
+            ),
+        ),
+        (
+            "threshold_band",
+            (1, "not_a_number"),
+            pytest.raises(
+                TypeError, match="`threshold_band` must contain numeric values"
+            ),
+        ),
+        (
+            "threshold_band",
+            (10, 5),
+            pytest.raises(
+                ValueError,
+                match=re.escape("`threshold_band` must be (min, max) with min < max"),
             ),
         ),
         (
@@ -88,14 +92,14 @@ import pynapple as nap
             ),
         ),
         (
-            "min_inter_duration",
+            "min_interval",
             "string",
-            pytest.raises(TypeError, match="`min_inter_duration` must be a number"),
+            pytest.raises(TypeError, match="`min_interval` must be a number"),
         ),
         (
-            "min_inter_duration",
+            "min_interval",
             -0.1,
-            pytest.raises(ValueError, match="`min_inter_duration` must be >= 0"),
+            pytest.raises(ValueError, match="`min_interval` must be >= 0"),
         ),
         (
             "fs",
@@ -108,27 +112,19 @@ import pynapple as nap
             pytest.raises(ValueError, match="`fs` must be > 0"),
         ),
         (
-            "wsize",
+            "sliding_window_size",
             "string",
-            pytest.raises(TypeError, match="`wsize` must be an integer"),
+            pytest.raises(TypeError, match="`sliding_window_size` must be an integer"),
         ),
         (
-            "wsize",
+            "sliding_window_size",
             -5,
-            pytest.raises(ValueError, match="`wsize` must be > 0"),
+            pytest.raises(ValueError, match="`sliding_window_size` must be > 0"),
         ),
         (
-            "wsize",
+            "sliding_window_size",
             0,
-            pytest.raises(ValueError, match="`wsize` must be > 0"),
-        ),
-        (
-            "wsize",
-            2,
-            pytest.raises(
-                ValueError,
-                match="`wsize` should be odd for symmetric smoothing",
-            ),
+            pytest.raises(ValueError, match="`sliding_window_size` must be > 0"),
         ),
         # Valid cases (does not raise exceptions)
         (
@@ -136,14 +132,14 @@ import pynapple as nap
             nap.Tsd(t=np.linspace(0, 5, 100), d=np.sin(np.linspace(0, 5, 100))),
             does_not_raise(),
         ),
-        ("epoch", nap.IntervalSet(start=0, end=5), does_not_raise()),
-        ("freq_band", (10, 30), does_not_raise()),
-        ("thresh_band", (1, 10), does_not_raise()),
+        ("epochs", nap.IntervalSet(start=0, end=5), does_not_raise()),
+        ("frequency_band", (10, 30), does_not_raise()),
+        ("threshold_band", (1, 10), does_not_raise()),
         ("duration_band", (0.1, 2), does_not_raise()),
-        ("min_inter_duration", 0.02, does_not_raise()),
+        ("min_interval", 0.02, does_not_raise()),
         ("fs", 1000, does_not_raise()),
         ("fs", None, does_not_raise()),
-        ("wsize", 51, does_not_raise()),
+        ("sliding_window_size", 51, does_not_raise()),
     ],
 )
 def test_detect_oscillatory_events_input_types(param_name, invalid_value, exception):
@@ -157,19 +153,19 @@ def test_detect_oscillatory_events_input_types(param_name, invalid_value, except
     min_dur = 0.1
     max_dur = 2
     min_inter = 0.02
-    freq_band = (10, 30)
-    thresh_band = (1, 10)
+    frequency_band = (10, 30)
+    threshold_band = (1, 10)
 
     # Modify the parameter based on the test case
     kwargs = {
         "data": ts,
-        "epoch": epoch,
-        "freq_band": freq_band,
-        "thresh_band": thresh_band,
+        "epochs": epoch,
+        "frequency_band": frequency_band,
+        "threshold_band": threshold_band,
         "duration_band": (min_dur, max_dur),
-        "min_inter_duration": min_inter,
+        "min_interval": min_inter,
         "fs": fs,
-        "wsize": 51,
+        "sliding_window_size": 51,
     }
     kwargs[param_name] = invalid_value
 
@@ -178,14 +174,16 @@ def test_detect_oscillatory_events_input_types(param_name, invalid_value, except
 
 
 @pytest.mark.parametrize(
-    "freq_band, thresh_band, num_events, start, end",
+    "frequency_band, threshold_band, num_events, start, end",
     [
         ((10, 30), (1, 10), 1, 0, 2),
         ((40, 60), (1, 10), 1, 3, 5),
         ((100, 150), (1, 10), 0, None, None),
     ],
 )
-def test_detect_oscillatory_events(freq_band, thresh_band, num_events, start, end):
+def test_detect_oscillatory_events(
+    frequency_band, threshold_band, num_events, start, end
+):
     fs = 1000
     duration = 5
     min_dur = 0.1
@@ -206,12 +204,17 @@ def test_detect_oscillatory_events(freq_band, thresh_band, num_events, start, en
     signal[mask2] = np.sin(2 * np.pi * freq_2 * t[mask2])
 
     ts = nap.Tsd(t=t, d=signal)
-    epoch = nap.IntervalSet(start=0, end=duration)
+    epochs = nap.IntervalSet(start=0, end=duration)
     osc_ep = nap.detect_oscillatory_events(
-        ts, epoch, freq_band, thresh_band, (min_dur, max_dur), min_inter
+        ts,
+        epochs,
+        frequency_band,
+        threshold_band,
+        (min_dur, max_dur),
+        min_inter,
     )
 
-    assert len(osc_ep) == num_events  # Only one event in given freq_band
+    assert len(osc_ep) == num_events  # Only one event in given frequency_band
 
     if num_events > 0:
         # Start and end should be close to actuals +/- a small amount

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -151,7 +151,7 @@ def test_detect_oscillatory_events_input_types(param_name, invalid_value, except
     duration = 5
     fs = 1000
     t = np.linspace(0, duration, int(fs * duration), endpoint=False)
-    signal = np.sin(2 * np.pi * 25 * t)  # simple 25 Hz signal
+    signal = np.sin(2 * np.pi * 25 * t)
     ts = nap.Tsd(t=t, d=signal)
     epoch = nap.IntervalSet(start=0, end=duration)
     min_dur = 0.1

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -1,3 +1,4 @@
+import re
 from contextlib import nullcontext as does_not_raise
 
 import numpy as np
@@ -5,6 +6,175 @@ import pytest
 from scipy.signal import hilbert
 
 import pynapple as nap
+
+
+@pytest.mark.parametrize(
+    "param_name, invalid_value, exception",
+    [
+        (
+            "data",
+            None,
+            pytest.raises(
+                TypeError, match="`data` must be `Tsd`, got <class 'NoneType'>"
+            ),
+        ),
+        (
+            "data",
+            "invalid_data",
+            pytest.raises(TypeError, match="`data` must be `Tsd`, got <class 'str'>"),
+        ),
+        (
+            "epoch",
+            None,
+            pytest.raises(
+                TypeError,
+                match="`epoch` must be `IntervalSet`, got <class 'NoneType'>",
+            ),
+        ),
+        (
+            "epoch",
+            "invalid_epoch",
+            pytest.raises(
+                TypeError,
+                match="`epoch` must be `IntervalSet`, got <class 'str'>",
+            ),
+        ),
+        (
+            "freq_band",
+            (10, "not_a_number"),
+            pytest.raises(TypeError, match="`freq_band` must contain numeric values"),
+        ),
+        (
+            "freq_band",
+            (10, 5),
+            pytest.raises(
+                ValueError,
+                match=re.escape("`freq_band` must be (min, max) with min < max"),
+            ),
+        ),
+        (
+            "thresh_band",
+            (1, "not_a_number"),
+            pytest.raises(TypeError, match="`thresh_band` must contain numeric values"),
+        ),
+        (
+            "thresh_band",
+            (10, 5),
+            pytest.raises(
+                ValueError,
+                match=re.escape("`thresh_band` must be (min, max) with min < max"),
+            ),
+        ),
+        (
+            "duration_band",
+            (1, "not_a_number"),
+            pytest.raises(
+                TypeError, match="`duration_band` must contain numeric values"
+            ),
+        ),
+        (
+            "duration_band",
+            (5,),
+            pytest.raises(
+                ValueError, match="`duration_band` must have length 2, got 1"
+            ),
+        ),
+        (
+            "duration_band",
+            (5, 1),
+            pytest.raises(
+                ValueError,
+                match=re.escape("`duration_band` must be (min, max) with min < max"),
+            ),
+        ),
+        (
+            "min_inter_duration",
+            "string",
+            pytest.raises(TypeError, match="`min_inter_duration` must be a number"),
+        ),
+        (
+            "min_inter_duration",
+            -0.1,
+            pytest.raises(ValueError, match="`min_inter_duration` must be >= 0"),
+        ),
+        (
+            "fs",
+            "string",
+            pytest.raises(TypeError, match="`fs` must be a number or None"),
+        ),
+        (
+            "fs",
+            -1,
+            pytest.raises(ValueError, match="`fs` must be > 0"),
+        ),
+        (
+            "wsize",
+            "string",
+            pytest.raises(TypeError, match="`wsize` must be an integer"),
+        ),
+        (
+            "wsize",
+            -5,
+            pytest.raises(ValueError, match="`wsize` must be > 0"),
+        ),
+        (
+            "wsize",
+            0,
+            pytest.raises(ValueError, match="`wsize` must be > 0"),
+        ),
+        (
+            "wsize",
+            2,
+            pytest.raises(
+                ValueError,
+                match="`wsize` should be odd for symmetric smoothing",
+            ),
+        ),
+        # Valid cases (does not raise exceptions)
+        (
+            "data",
+            nap.Tsd(t=np.linspace(0, 5, 100), d=np.sin(np.linspace(0, 5, 100))),
+            does_not_raise(),
+        ),
+        ("epoch", nap.IntervalSet(start=0, end=5), does_not_raise()),
+        ("freq_band", (10, 30), does_not_raise()),
+        ("thresh_band", (1, 10), does_not_raise()),
+        ("duration_band", (0.1, 2), does_not_raise()),
+        ("min_inter_duration", 0.02, does_not_raise()),
+        ("fs", 1000, does_not_raise()),
+        ("fs", None, does_not_raise()),
+        ("wsize", 51, does_not_raise()),
+    ],
+)
+def test_detect_oscillatory_events_input_types(param_name, invalid_value, exception):
+    # Create some valid input values for other parameters
+    duration = 5
+    fs = 1000
+    t = np.linspace(0, duration, int(fs * duration), endpoint=False)
+    signal = np.sin(2 * np.pi * 25 * t)  # simple 25 Hz signal
+    ts = nap.Tsd(t=t, d=signal)
+    epoch = nap.IntervalSet(start=0, end=duration)
+    min_dur = 0.1
+    max_dur = 2
+    min_inter = 0.02
+    freq_band = (10, 30)
+    thresh_band = (1, 10)
+
+    # Modify the parameter based on the test case
+    kwargs = {
+        "data": ts,
+        "epoch": epoch,
+        "freq_band": freq_band,
+        "thresh_band": thresh_band,
+        "duration_band": (min_dur, max_dur),
+        "min_inter_duration": min_inter,
+        "fs": fs,
+        "wsize": 51,
+    }
+    kwargs[param_name] = invalid_value
+
+    with exception:
+        nap.detect_oscillatory_events(**kwargs)
 
 
 @pytest.mark.parametrize(
@@ -106,7 +276,10 @@ def test_hilbert_type_errors(input, func, expectation):
         nap.TsdFrame(
             t=np.linspace(0, 1, 500),
             d=np.stack(
-                [np.sin(np.linspace(0, 1, 500)), np.cos(np.linspace(0, 1, 500))],
+                [
+                    np.sin(np.linspace(0, 1, 500)),
+                    np.cos(np.linspace(0, 1, 500)),
+                ],
                 axis=1,
             ),
         ),
@@ -130,7 +303,10 @@ def test_apply_hilbert_transform(data):
         nap.TsdFrame(
             t=np.linspace(0, 1, 500),
             d=np.stack(
-                [np.sin(np.linspace(0, 1, 500)), np.cos(np.linspace(0, 1, 500))],
+                [
+                    np.sin(np.linspace(0, 1, 500)),
+                    np.cos(np.linspace(0, 1, 500)),
+                ],
                 axis=1,
             ),
         ),
@@ -156,7 +332,10 @@ def test_compute_hilbert_phase(data):
         nap.TsdFrame(
             t=np.linspace(0, 1, 500),
             d=np.stack(
-                [np.sin(np.linspace(0, 1, 500)), np.cos(np.linspace(0, 1, 500))],
+                [
+                    np.sin(np.linspace(0, 1, 500)),
+                    np.cos(np.linspace(0, 1, 500)),
+                ],
                 axis=1,
             ),
         ),


### PR DESCRIPTION
This short PR updates `detect_oscillatory_events` to use the hilbert transform vs. `filt.filt` before.

It further adds a snippet at the end of the new ripple detection tutorial where it is introduced and uses as a shorter version of everything that came before.

I've further added input type checks to the function and a test for them.

Addresses #587 