### PR TITLE
Load `ElectrodesTable` metadata when loading `ElectricalSeries` from NWB file

### DIFF
--- a/pynapple/io/interface_nwb.py
+++ b/pynapple/io/interface_nwb.py
@@ -235,9 +235,13 @@ def _make_tsd_frame(obj, lazy_loading=True):
         # (channel mapping)
         try:
             df = obj.electrodes.to_dataframe()
-            if hasattr(df, "label"):
-                columns = df["label"].values
-            else:
+            key_missing = True
+            for k in ["channel_name", "label"]:
+                if hasattr(df, k):
+                    columns = df[k].values
+                    key_missing = True
+                    break
+            if key_missing:
                 columns = df.index.values
         except Exception:
             columns = np.arange(obj.data.shape[1])

--- a/pynapple/io/interface_nwb.py
+++ b/pynapple/io/interface_nwb.py
@@ -61,7 +61,7 @@ def iterate_over_nwb(nwbfile):
     pynwb = importlib.import_module("pynwb")
     for oid, obj in nwbfile.objects.items():
         if isinstance(obj, pynwb.misc.DynamicTable) and any(
-            [i.name.endswith("_times_index") for i in obj.columns]
+            i.name.endswith("_times_index") for i in obj.columns
         ):
             # data["units"] = {"id": oid, "type": "TsGroup"}
             yield obj, {"id": oid, "type": "TsGroup"}
@@ -71,7 +71,7 @@ def iterate_over_nwb(nwbfile):
             yield obj, {"id": oid, "type": "IntervalSet"}
 
         elif isinstance(obj, pynwb.misc.DynamicTable) and any(
-            [i.name.endswith("_times") for i in obj.columns]
+            i.name.endswith("_times") for i in obj.columns
         ):
             # Supposedly Timestamps
             yield obj, {"id": oid, "type": "Ts"}
@@ -215,6 +215,7 @@ def _make_tsd_frame(obj, lazy_loading=True):
     pynwb = importlib.import_module("pynwb")
 
     d = obj.data
+    metadata = {}
     if not lazy_loading:
         d = d[:]
 
@@ -234,15 +235,12 @@ def _make_tsd_frame(obj, lazy_loading=True):
     elif isinstance(obj, pynwb.ecephys.ElectricalSeries):
         # (channel mapping)
         try:
-            df = obj.electrodes.to_dataframe()
-            key_missing = True
-            for k in ["channel_name", "label"]:
-                if hasattr(df, k):
-                    columns = df[k].values
-                    key_missing = True
-                    break
-            if key_missing:
-                columns = df.index.values
+            metadata = (
+                obj.electrodes.to_dataframe()
+                .convert_dtypes()
+                .select_dtypes(exclude="object")
+            )
+            columns = metadata.index
         except Exception:
             columns = np.arange(obj.data.shape[1])
 
@@ -261,7 +259,13 @@ def _make_tsd_frame(obj, lazy_loading=True):
     else:
         columns = np.arange(obj.data.shape[1])
 
-    data = nap.TsdFrame(t=t, d=d, columns=columns, load_array=not lazy_loading)
+    data = nap.TsdFrame(
+        t=t,
+        d=d,
+        columns=columns,
+        load_array=not lazy_loading,
+        metadata=metadata,
+    )
 
     return data
 
@@ -317,7 +321,13 @@ def _make_tsgroup(obj, **kwargs):
                         column_not_yet_set = k not in metainfo
                         if column_not_yet_set and not isinstance(
                             df[k].values[0],
-                            (list, tuple, dict, set, pynwb.ecephys.ElectrodeGroup),
+                            (
+                                list,
+                                tuple,
+                                dict,
+                                set,
+                                pynwb.ecephys.ElectrodeGroup,
+                            ),
                         ):
                             metainfo[k] = df[k].values
                 # elif not isinstance(col[0], (np.ndarray, list, tuple, dict, set)):

--- a/pynapple/io/loader.py
+++ b/pynapple/io/loader.py
@@ -41,7 +41,9 @@ def get_error_text(path):
 
     A more advanced project for creating NWB files is neuroconv:
     https://neuroconv.readthedocs.io/en/main/
-    """.format(path)
+    """.format(
+        path
+    )
 
     error_txt = "\n" + border + "\n" + txt1 + "\n" + border
     return error_txt
@@ -110,7 +112,9 @@ class BaseLoader(object):
             if "position_time_support" in nwbfile.intervals.keys():
                 epochs = nwbfile.intervals["position_time_support"].to_dataframe()
                 time_support = nap.IntervalSet(
-                    start=epochs["start_time"], end=epochs["stop_time"], time_units="s"
+                    start=epochs["start_time"],
+                    end=epochs["stop_time"],
+                    time_units="s",
                 )
 
             self.position = nap.TsdFrame(
@@ -126,6 +130,16 @@ class BaseLoader(object):
             self.epochs = self._make_epochs(epochs)
 
             self.time_support = self._join_epochs(epochs, "s")
+
+        if nwbfile.processing is not None:
+            import numpy as np
+
+            lfp = nwbfile.processing["ecephys"]["LFP"]["LFP"]
+            timestamps = np.arange(0, len(lfp.data)) * 1 / lfp.rate
+            columns = nwbfile.processing["ecephys"]["LFP"]["LFP"].electrodes[:][
+                "channel_name"
+            ]
+            self.LFP = nap.TsdFrame(d=lfp.data[:], t=timestamps, columns=columns)
 
         io.close()
 
@@ -218,7 +232,8 @@ class BaseLoader(object):
             timestamps=tsd.as_units("s").index.values,
         )
         time_support = pynwb.epoch.TimeIntervals(
-            name=name + "_timesupport", description="The time support of the object"
+            name=name + "_timesupport",
+            description="The time support of the object",
         )
 
         epochs = tsd.time_support.as_units("s")
@@ -251,7 +266,9 @@ class BaseLoader(object):
         if name in nwbfile.intervals.keys():
             epochs = nwbfile.intervals[name].to_dataframe()
             isets = nap.IntervalSet(
-                start=epochs["start_time"], end=epochs["stop_time"], time_units="s"
+                start=epochs["start_time"],
+                end=epochs["stop_time"],
+                time_units="s",
             )
             io.close()
             return isets
@@ -282,7 +299,10 @@ class BaseLoader(object):
         time_support = self.load_nwb_intervals(name + "_timesupport")
 
         tsd = nap.Tsd(
-            t=ts.timestamps[:], d=ts.data[:], time_units="s", time_support=time_support
+            t=ts.timestamps[:],
+            d=ts.data[:],
+            time_units="s",
+            time_support=time_support,
         )
 
         io.close()

--- a/pynapple/io/loader.py
+++ b/pynapple/io/loader.py
@@ -41,7 +41,9 @@ def get_error_text(path):
 
     A more advanced project for creating NWB files is neuroconv:
     https://neuroconv.readthedocs.io/en/main/
-    """.format(path)
+    """.format(
+        path
+    )
 
     error_txt = "\n" + border + "\n" + txt1 + "\n" + border
     return error_txt
@@ -108,9 +110,7 @@ class BaseLoader(object):
 
             # retrieveing time support position if in epochs
             if "position_time_support" in nwbfile.intervals.keys():
-                epochs = nwbfile.intervals[
-                    "position_time_support"
-                ].to_dataframe()
+                epochs = nwbfile.intervals["position_time_support"].to_dataframe()
                 time_support = nap.IntervalSet(
                     start=epochs["start_time"],
                     end=epochs["stop_time"],
@@ -126,9 +126,7 @@ class BaseLoader(object):
             # NWB is dumb and cannot take a single string for labels
             epochs["label"] = [epochs.loc[i, "tags"][0] for i in epochs.index]
             epochs = epochs.drop(labels="tags", axis=1)
-            epochs = epochs.rename(
-                columns={"start_time": "start", "stop_time": "end"}
-            )
+            epochs = epochs.rename(columns={"start_time": "start", "stop_time": "end"})
             self.epochs = self._make_epochs(epochs)
 
             self.time_support = self._join_epochs(epochs, "s")
@@ -201,9 +199,7 @@ class BaseLoader(object):
         nwbfile = io.read()
 
         epochs = iset.as_units("s")
-        time_intervals = pynwb.epoch.TimeIntervals(
-            name=name, description=description
-        )
+        time_intervals = pynwb.epoch.TimeIntervals(name=name, description=description)
         for i in epochs.index:
             time_intervals.add_interval(
                 start_time=epochs.loc[i, "start"],

--- a/pynapple/io/loader.py
+++ b/pynapple/io/loader.py
@@ -41,9 +41,7 @@ def get_error_text(path):
 
     A more advanced project for creating NWB files is neuroconv:
     https://neuroconv.readthedocs.io/en/main/
-    """.format(
-        path
-    )
+    """.format(path)
 
     error_txt = "\n" + border + "\n" + txt1 + "\n" + border
     return error_txt
@@ -110,7 +108,9 @@ class BaseLoader(object):
 
             # retrieveing time support position if in epochs
             if "position_time_support" in nwbfile.intervals.keys():
-                epochs = nwbfile.intervals["position_time_support"].to_dataframe()
+                epochs = nwbfile.intervals[
+                    "position_time_support"
+                ].to_dataframe()
                 time_support = nap.IntervalSet(
                     start=epochs["start_time"],
                     end=epochs["stop_time"],
@@ -126,7 +126,9 @@ class BaseLoader(object):
             # NWB is dumb and cannot take a single string for labels
             epochs["label"] = [epochs.loc[i, "tags"][0] for i in epochs.index]
             epochs = epochs.drop(labels="tags", axis=1)
-            epochs = epochs.rename(columns={"start_time": "start", "stop_time": "end"})
+            epochs = epochs.rename(
+                columns={"start_time": "start", "stop_time": "end"}
+            )
             self.epochs = self._make_epochs(epochs)
 
             self.time_support = self._join_epochs(epochs, "s")
@@ -199,7 +201,9 @@ class BaseLoader(object):
         nwbfile = io.read()
 
         epochs = iset.as_units("s")
-        time_intervals = pynwb.epoch.TimeIntervals(name=name, description=description)
+        time_intervals = pynwb.epoch.TimeIntervals(
+            name=name, description=description
+        )
         for i in epochs.index:
             time_intervals.add_interval(
                 start_time=epochs.loc[i, "start"],

--- a/pynapple/io/loader.py
+++ b/pynapple/io/loader.py
@@ -41,7 +41,9 @@ def get_error_text(path):
 
     A more advanced project for creating NWB files is neuroconv:
     https://neuroconv.readthedocs.io/en/main/
-    """.format(path)
+    """.format(
+        path
+    )
 
     error_txt = "\n" + border + "\n" + txt1 + "\n" + border
     return error_txt

--- a/pynapple/io/loader.py
+++ b/pynapple/io/loader.py
@@ -41,7 +41,9 @@ def get_error_text(path):
 
     A more advanced project for creating NWB files is neuroconv:
     https://neuroconv.readthedocs.io/en/main/
-    """.format(path)
+    """.format(
+        path
+    )
 
     error_txt = "\n" + border + "\n" + txt1 + "\n" + border
     return error_txt
@@ -128,23 +130,6 @@ class BaseLoader(object):
             self.epochs = self._make_epochs(epochs)
 
             self.time_support = self._join_epochs(epochs, "s")
-
-        if nwbfile.processing is not None:
-            import numpy as np
-
-            lfp = nwbfile.processing["ecephys"]["LFP"]["LFP"]
-            timestamps = np.arange(0, len(lfp.data)) * 1 / lfp.rate
-            metadata = (
-                nwbfile.processing["ecephys"]["LFP"]["LFP"]
-                .electrodes[:]
-                .convert_dtypes()
-            )
-            self.LFP = nap.TsdFrame(
-                d=lfp.data[:],
-                t=timestamps,
-                columns=metadata.index,
-                metadata=metadata,
-            )
 
         io.close()
 

--- a/pynapple/io/loader.py
+++ b/pynapple/io/loader.py
@@ -41,9 +41,7 @@ def get_error_text(path):
 
     A more advanced project for creating NWB files is neuroconv:
     https://neuroconv.readthedocs.io/en/main/
-    """.format(
-        path
-    )
+    """.format(path)
 
     error_txt = "\n" + border + "\n" + txt1 + "\n" + border
     return error_txt

--- a/pynapple/io/loader.py
+++ b/pynapple/io/loader.py
@@ -136,10 +136,17 @@ class BaseLoader(object):
 
             lfp = nwbfile.processing["ecephys"]["LFP"]["LFP"]
             timestamps = np.arange(0, len(lfp.data)) * 1 / lfp.rate
-            columns = nwbfile.processing["ecephys"]["LFP"]["LFP"].electrodes[:][
-                "channel_name"
-            ]
-            self.LFP = nap.TsdFrame(d=lfp.data[:], t=timestamps, columns=columns)
+            metadata = (
+                nwbfile.processing["ecephys"]["LFP"]["LFP"]
+                .electrodes[:]
+                .convert_dtypes()
+            )
+            self.LFP = nap.TsdFrame(
+                d=lfp.data[:],
+                t=timestamps,
+                columns=metadata.index,
+                metadata=metadata,
+            )
 
         io.close()
 

--- a/tests/test_nwb.py
+++ b/tests/test_nwb.py
@@ -64,7 +64,6 @@ class Test_NWB:
         assert len(lfp.columns) == 10
         assert len(lfp) == 1000
         assert not np.all(np.isnan(lfp.values))
-        assert all(col == f"CH{i}" for i, col in enumerate(lfp.columns, 1))
 
     @pytest.mark.filterwarnings("ignore")
     def test_nwb_meta_info(self, data):

--- a/tests/test_nwb.py
+++ b/tests/test_nwb.py
@@ -9,6 +9,7 @@
 import warnings
 
 import numpy as np
+import pandas as pd
 import pynwb
 import pytest
 from pynwb.testing.mock.file import mock_NWBFile
@@ -57,9 +58,17 @@ class Test_NWB:
     def test_time_support(self, data):
         assert isinstance(data.time_support, nap.IntervalSet)
 
+    def test_electrical_series(self, data):
+        lfp = data.LFP
+        assert isinstance(lfp, nap.TsdFrame)
+        assert len(lfp.columns) == 10
+        assert len(lfp) == 1000
+        assert not np.all(np.isnan(lfp.values))
+        assert all(col == f"CH{i}" for i, col in enumerate(lfp.columns, 1))
+
     @pytest.mark.filterwarnings("ignore")
     def test_nwb_meta_info(self, data):
-        from pynwb import NWBHDF5IO, NWBFile
+        from pynwb import NWBHDF5IO
 
         io = NWBHDF5IO(data.nwbfilepath, "r")
         nwbfile = io.read()
@@ -91,6 +100,7 @@ def test_NWBFile():
     assert nwb.keys() == [
         "position_time_support",
         "epochs",
+        "LFP",
         "z",
         "y",
         "x",
@@ -195,7 +205,12 @@ def test_add_SpatialSeries():
 
     for name, Series in zip(
         ["SpatialSeries", "Position", "PupilTracking", "CompassDirection"],
-        [mock_SpatialSeries, mock_Position, mock_PupilTracking, mock_CompassDirection],
+        [
+            mock_SpatialSeries,
+            mock_Position,
+            mock_PupilTracking,
+            mock_CompassDirection,
+        ],
     ):
         name_generator_registry.clear()
         nwbfile = mock_NWBFile()
@@ -255,7 +270,8 @@ def test_add_Ecephys():
 
         name_generator_registry.clear()
         nwbfile = mock_NWBFile()
-        nwbfile.add_acquisition(mock_ElectricalSeries())
+        mock_series = mock_ElectricalSeries()
+        nwbfile.add_acquisition(mock_series)
         nwb = nap.NWBFile(nwbfile)
         assert len(nwb) == 1
         assert "ElectricalSeries" in nwb.keys()
@@ -264,11 +280,16 @@ def test_add_Ecephys():
         obj = nwbfile.acquisition["ElectricalSeries"]
         np.testing.assert_array_almost_equal(data.values, obj.data[:])
         np.testing.assert_array_almost_equal(
-            data.index, obj.starting_time + np.arange(obj.num_samples) / obj.rate
+            data.index,
+            obj.starting_time + np.arange(obj.num_samples) / obj.rate,
         )
         np.testing.assert_array_almost_equal(
             data.columns.values, obj.electrodes["id"][:]
         )
+        metadata = (
+            mock_series.electrodes[:].convert_dtypes().select_dtypes(exclude="object")
+        )
+        pd.testing.assert_frame_equal(data.metadata.convert_dtypes(), metadata)
 
         # Try ElectrialSeries without channel mapping
         name_generator_registry.clear()
@@ -282,7 +303,8 @@ def test_add_Ecephys():
         obj = nwbfile.acquisition["ElectricalSeries"]
         np.testing.assert_array_almost_equal(data.values, obj.data[:])
         np.testing.assert_array_almost_equal(
-            data.index, obj.starting_time + np.arange(obj.num_samples) / obj.rate
+            data.index,
+            obj.starting_time + np.arange(obj.num_samples) / obj.rate,
         )
         np.testing.assert_array_almost_equal(
             data.columns.values, np.arange(obj.data.shape[1])
@@ -496,7 +518,9 @@ def test_add_Units():
             np.where(np.random.rand((res * duration)) < (firing_rate / res))[0] / res
         )
         nwbfile.add_unit(
-            spike_times=spike_times, quality="good", alpha=alpha[n_units_per_shank]
+            spike_times=spike_times,
+            quality="good",
+            alpha=alpha[n_units_per_shank],
         )
         spks[n_units_per_shank] = spike_times
 
@@ -671,7 +695,9 @@ def test_add_object_with_same_name():
     processing_module = ProcessingModule(name="processed", description="processed data")
     processing_module.add(
         mock_TimeSeries(
-            name="timeseries", data=np.random.randn(100), timestamps=np.arange(100)
+            name="timeseries",
+            data=np.random.randn(100),
+            timestamps=np.arange(100),
         )
     )
 
@@ -709,7 +735,12 @@ def test_add_object_with_same_name():
         ),
         (
             {"/a/b/c": "c", "/a/e/c": "c", "/a/e/d": "d", "/x/e/d": "d"},
-            {"/a/b/c": "b/c", "/a/e/c": "e/c", "/a/e/d": "a/e/d", "/x/e/d": "x/e/d"},
+            {
+                "/a/b/c": "b/c",
+                "/a/e/c": "e/c",
+                "/a/e/d": "a/e/d",
+                "/x/e/d": "x/e/d",
+            },
         ),
     ],
 )

--- a/tests/test_nwb.py
+++ b/tests/test_nwb.py
@@ -58,13 +58,6 @@ class Test_NWB:
     def test_time_support(self, data):
         assert isinstance(data.time_support, nap.IntervalSet)
 
-    def test_electrical_series(self, data):
-        lfp = data.LFP
-        assert isinstance(lfp, nap.TsdFrame)
-        assert len(lfp.columns) == 10
-        assert len(lfp) == 1000
-        assert not np.all(np.isnan(lfp.values))
-
     @pytest.mark.filterwarnings("ignore")
     def test_nwb_meta_info(self, data):
         from pynwb import NWBHDF5IO
@@ -99,7 +92,6 @@ def test_NWBFile():
     assert nwb.keys() == [
         "position_time_support",
         "epochs",
-        "LFP",
         "z",
         "y",
         "x",


### PR DESCRIPTION
This PR adds the metadata in the `ElectrodesTable` as `TsdFrame` metadata when loading a `ElectricalSeries` from a NWB file using `load_file`.

Before we only looked for `"label"`, since that is an example in `pynwb`.
However, it seems that `neuroconv` uses `"channel_name"`.
There doesn't seem to be a standard for the columns in the `ElectrodesTable`.

The solution I came up with was to make the `TsdFrame` column names the index of the `ElectrodesTable` and then add all the columns of the `ElectrodesTable` that do not have `object` as type as metadata columns in the `TsdFrame`.
This way things like location are also loaded.

Addresses #586 