### PR TITLE
A `find_peaks` method for `Tsd` and `TsdFrame`

### DIFF
--- a/doc/user_guide/03_core_methods.md
+++ b/doc/user_guide/03_core_methods.md
@@ -432,6 +432,112 @@ plt.title("tsd.threshold(0.5)")
 plt.show()
 ```
 
+### `find_peaks`
+
+The [`find_peaks`](pynapple.Tsd.find_peaks) method detects local maxima in a `Tsd` or `TsdFrame`. 
+It wraps [`scipy.signal.find_peaks`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.find_peaks.html) 
+and returns the time points and values of the detected peaks.
+
+```{code-cell} ipython3
+:tags: [hide-cell]
+np.random.seed(0)
+times = np.arange(0, 4, 0.01)
+signal = np.sin(2 * np.pi * 1 * times) + 0.4 * np.sin(2 * np.pi * 5 * times)
+tsd = nap.Tsd(t=times, d=signal)
+```
+
+```{code-cell} ipython3
+peaks = tsd.find_peaks()
+print(peaks)
+```
+
+```{code-cell} ipython3
+:tags: [hide-input]
+plt.figure()
+plt.plot(tsd, label="tsd")
+plt.plot(peaks, 'o', label="peaks", markersize=8)
+plt.xlabel("Time (s)")
+plt.title("tsd.find_peaks()")
+plt.show()
+```
+
+The parameter `height` can be used to set a minimum height for the peaks. This is useful to filter out small peaks that may be due to noise.
+
+```{code-cell} ipython3
+peak_height = tsd.find_peaks(height=0.5)
+print(peak_height)
+```
+
+```{code-cell} ipython3
+:tags: [hide-input]
+plt.figure()
+plt.plot(tsd, label="tsd")
+plt.plot(peak_height, 'o', markersize=8)
+plt.xlabel("Time (s)")
+plt.title("tsd.find_peaks(height=0.5)")
+plt.axhline(0.5, linewidth=0.5, color='grey')
+plt.show()
+```
+
+For `TsdFrame`, [`find_peaks`](pynapple.TsdFrame.find_peaks) applies the detection independently to each column and returns a `TsGroup` where each entry corresponds to one column.
+
+```{code-cell} ipython3
+:tags: [hide-cell]
+np.random.seed(0)
+times = np.arange(0, 4, 0.01)
+sig1 = np.sin(2 * np.pi * 1 * times) + 0.4 * np.sin(2 * np.pi * 5 * times)
+sig2 = np.sin(2 * np.pi * 2 * times) + 0.3 * np.sin(2 * np.pi * 7 * times)
+tsdframe = nap.TsdFrame(t=times, d=np.stack([sig1, sig2], axis=1), columns=['A', 'B'])
+```
+
+```{code-cell} ipython3
+peaks_frame = tsdframe.find_peaks(height=0.5)
+print(peaks_frame)
+```
+
+```{code-cell} ipython3
+:tags: [hide-input]
+plt.figure()
+plt.plot(tsdframe, label=tsdframe.columns)
+for i, col in enumerate(tsdframe.columns):
+    plt.plot(peaks_frame[i], 'o', markersize=8)
+plt.xlabel("Time (s)")
+plt.title("tsdframe.find_peaks()")
+plt.axhline(0.5, linewidth=0.5, color='grey')
+plt.legend()
+plt.show()
+```
+
+You can also pass `epochs` to restrict the peak detection to specific time intervals.
+
+```{code-cell} ipython3
+:tags: [hide-cell]
+intervalset = nap.IntervalSet(start=[0.5, 2.5], end=[1.5, 3.5])
+```
+```{code-cell} ipython3
+peaks_epoch = tsdframe.find_peaks(epochs=intervalset, height=0.5)
+print(peaks_epoch)
+```
+```{code-cell} ipython3
+:tags: [hide-input]
+plt.figure()
+plt.plot(tsdframe, label=tsdframe.columns)
+for i, col in enumerate(tsdframe.columns):
+    plt.plot(peaks_epoch[i], 'o', markersize=8)
+[plt.axvspan(s, e, alpha=0.2) for s, e in intervalset.values]
+plt.xlabel("Time (s)")
+plt.title("tsdframe.find_peaks(epochs=intervalset)")
+plt.axhline(0.5, linewidth=0.5, color='grey')
+plt.legend()
+plt.show()
+```
+
+The time support of the resulting `TsGroup` is updated to reflect the epochs used for peak detection.
+
+```{code-cell} ipython3
+print("Peak time support:", peaks_epoch.time_support)
+```
+
 ### `derivative`
 
 The [`derivative`](pynapple.Tsd.derivative) method of `Tsd`, `TsdFrame` and `TsdTensor` can be used to calculate the derivative of a time series with respect to time. It is a wrapper of [`numpy.gradient`](https://numpy.org/devdocs/reference/generated/numpy.gradient.html).

--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -2177,6 +2177,94 @@ class TsdFrame(_BaseTsd, _MetadataMixin):
         """
         return _Base.time_diff(self, align, epochs)
 
+    def find_peaks(self, epochs=None, return_prop=False, *args):
+        """
+        Find peaks based on peak properties.
+
+        This function wraps :func:`scipy.signal.find_peaks`.
+
+        Parameters
+        ----------
+        return_prop : bool, optional
+            Whether to return the peak properties in the columns.
+            See :func:`scipy.signal.find_peaks` for the list of properties.
+        height : number or ndarray or sequence, optional
+            Required height of peaks. Either a number, ``None``, an array matching
+            `x` or a 2-element sequence of the former. The first element is
+            always interpreted as the  minimal and the second, if supplied, as the
+            maximal required height.
+        threshold : number or ndarray or sequence, optional
+            Required threshold of peaks, the vertical distance to its neighboring
+            samples. Either a number, ``None``, an array matching `x` or a
+            2-element sequence of the former. The first element is always
+            interpreted as the  minimal and the second, if supplied, as the maximal
+            required threshold.
+        distance : number, optional
+            Required minimal horizontal distance (>= 1) in samples between
+            neighbouring peaks. Smaller peaks are removed first until the condition
+            is fulfilled for all remaining peaks.
+        prominence : number or ndarray or sequence, optional
+            Required prominence of peaks. Either a number, ``None``, an array
+            matching `x` or a 2-element sequence of the former. The first
+            element is always interpreted as the  minimal and the second, if
+            supplied, as the maximal required prominence.
+        width : number or ndarray or sequence, optional
+            Required width of peaks in samples. Either a number, ``None``, an array
+            matching `x` or a 2-element sequence of the former. The first
+            element is always interpreted as the  minimal and the second, if
+            supplied, as the maximal required width.
+        wlen : int, optional
+            Used for calculation of the peaks prominences, thus it is only used if
+            one of the arguments `prominence` or `width` is given. See argument
+            `wlen` in `peak_prominences` for a full description of its effects.
+        rel_height : float, optional
+            Used for calculation of the peaks width, thus it is only used if `width`
+            is given. See argument  `rel_height` in `peak_widths` for a full
+            description of its effects.
+        plateau_size : number or ndarray or sequence, optional
+            Required size of the flat top of peaks in samples. Either a number,
+            ``None``, an array matching `x` or a 2-element sequence of the former.
+            The first element is always interpreted as the minimal and the second,
+            if supplied as the maximal required plateau size.
+
+        Returns
+        -------
+        peaks : dict
+            The time points and values of the peaks per column.
+        properties : dict
+            A dictionary containing properties of the returned peaks which were
+            calculated as intermediate results during evaluation of the specified
+            conditions, see :func:`scipy.signal.find_peaks`.
+
+        Examples
+        --------
+        >>> import pynapple as nap
+        >>> import numpy as np
+        >>> times = np.arange(0, 10, 0.1)
+        >>> tsdframe = nap.TsdFrame(t=times, d=np.stack([np.sin(times), np.cos(times)], axis=1))
+        >>> peaks = tsdframe.find_peaks()
+        >>> peaks
+          Index     rate
+        -------  -------
+              0  0.20202
+              1  0.10101
+        """
+        from .ts_group import TsGroup
+
+        if epochs is None:
+            epochs = self.time_support
+
+        data = self.restrict(epochs)
+        return TsGroup(
+            {
+                col: Tsd(t=data.t, d=data.values[:, i], time_support=epochs).find_peaks(
+                    epochs, return_prop, *args
+                )
+                for i, col in enumerate(self.columns)
+            },
+            time_support=epochs,
+        )
+
     # @add_or_convert_metadata
     def save(self, filename):
         """
@@ -3278,6 +3366,96 @@ class Tsd(_BaseTsd):
         return ts_group.TsGroup(
             group, time_support=self.time_support, bypass_check=True
         )
+
+    def find_peaks(self, epochs=None, return_prop=False, *args):
+        """
+        Find peaks based on peak properties.
+
+        This function wraps :func:`scipy.signal.find_peaks`.
+
+        Parameters
+        ----------
+        return_prop : bool, optional
+            Whether to return the peak properties in the columns.
+            See :func:`scipy.signal.find_peaks` for the list of properties.
+        height : number or ndarray or sequence, optional
+            Required height of peaks. Either a number, ``None``, an array matching
+            `x` or a 2-element sequence of the former. The first element is
+            always interpreted as the  minimal and the second, if supplied, as the
+            maximal required height.
+        threshold : number or ndarray or sequence, optional
+            Required threshold of peaks, the vertical distance to its neighboring
+            samples. Either a number, ``None``, an array matching `x` or a
+            2-element sequence of the former. The first element is always
+            interpreted as the  minimal and the second, if supplied, as the maximal
+            required threshold.
+        distance : number, optional
+            Required minimal horizontal distance (>= 1) in samples between
+            neighbouring peaks. Smaller peaks are removed first until the condition
+            is fulfilled for all remaining peaks.
+        prominence : number or ndarray or sequence, optional
+            Required prominence of peaks. Either a number, ``None``, an array
+            matching `x` or a 2-element sequence of the former. The first
+            element is always interpreted as the  minimal and the second, if
+            supplied, as the maximal required prominence.
+        width : number or ndarray or sequence, optional
+            Required width of peaks in samples. Either a number, ``None``, an array
+            matching `x` or a 2-element sequence of the former. The first
+            element is always interpreted as the  minimal and the second, if
+            supplied, as the maximal required width.
+        wlen : int, optional
+            Used for calculation of the peaks prominences, thus it is only used if
+            one of the arguments `prominence` or `width` is given. See argument
+            `wlen` in `peak_prominences` for a full description of its effects.
+        rel_height : float, optional
+            Used for calculation of the peaks width, thus it is only used if `width`
+            is given. See argument  `rel_height` in `peak_widths` for a full
+            description of its effects.
+        plateau_size : number or ndarray or sequence, optional
+            Required size of the flat top of peaks in samples. Either a number,
+            ``None``, an array matching `x` or a 2-element sequence of the former.
+            The first element is always interpreted as the minimal and the second,
+            if supplied as the maximal required plateau size.
+
+        Returns
+        -------
+        peaks : Tsd, TsdFrame
+            The time points and values of the peaks.
+            Peak properties are included as columns if `return_prop=True`.
+
+        Examples
+        --------
+        >>> import pynapple as nap
+        >>> import numpy as np
+        >>> times = np.arange(0, 10, 0.1)
+        >>> tsd = nap.Tsd(t=times, d=np.sin(times))
+        >>> peaks = tsd.find_peaks()
+        >>> peaks
+        Time (s)
+        ----------  --------
+        1.6         0.999574
+        7.9         0.998941
+        dtype: float64, shape: (2,)
+        """
+        from scipy.signal import find_peaks
+
+        if epochs is None:
+            epochs = self.time_support
+
+        data = self.restrict(epochs)
+        peaks, properties = find_peaks(data.values, *args)
+        times = data.t[peaks]
+        values = data.values[peaks]
+
+        if return_prop:
+            return TsdFrame(
+                t=times,
+                d=np.stack([values] + list(properties.values()), axis=1),
+                columns=["peak_value"] + list(properties.keys()),
+                time_support=epochs,
+            )
+        else:
+            return Tsd(t=times, d=values, time_support=epochs)
 
     def save(self, filename):
         """

--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -2177,7 +2177,7 @@ class TsdFrame(_BaseTsd, _MetadataMixin):
         """
         return _Base.time_diff(self, align, epochs)
 
-    def find_peaks(self, epochs=None, return_prop=False, *args):
+    def find_peaks(self, epochs=None, return_prop=False, *args, **kwargs):
         """
         Find peaks based on peak properties.
 
@@ -2229,12 +2229,9 @@ class TsdFrame(_BaseTsd, _MetadataMixin):
 
         Returns
         -------
-        peaks : dict
+        peaks : TsGroup
             The time points and values of the peaks per column.
-        properties : dict
-            A dictionary containing properties of the returned peaks which were
-            calculated as intermediate results during evaluation of the specified
-            conditions, see :func:`scipy.signal.find_peaks`.
+            Peak properties are included in the entry columns if ``return_prop=True``.
 
         Examples
         --------
@@ -2248,17 +2245,58 @@ class TsdFrame(_BaseTsd, _MetadataMixin):
         -------  -------
               0  0.20202
               1  0.10101
+        >>> peaks[0]
+        Time (s)
+        ----------  --------
+        1.6         0.999574
+        7.9         0.998941
+        dtype: float64, shape: (2,)
+
+        You can set various requirements for finding peaks, for example a minimum width:
+
+        >>> peaks = tsdframe.find_peaks(width=21)
+        >>> peaks
+          Index     rate
+        -------  -------
+              0  0.10101
+              1  0.10101
+        >>> peaks[0]
+        Time (s)
+        ----------  --------
+        7.9         0.998941
+        dtype: float64, shape: (1,)
+
+        If you further want the peak properties returned, you can pass `return_prop=True`:
+
+        >>> peaks = tsdframe.find_peaks(return_prop=True, width=21)
+        >>> peaks
+          Index     rate
+        -------  -------
+              0  0.10101
+              1  0.10101
+        >>> peaks[0]
+        Time (s)      peak_value    prominences    left_bases    right_bases    widths  ...
+        ----------  ------------  -------------  ------------  -------------  --------  -----
+        7.9             0.998941        1.45648            47             99   25.9266  ...
+        dtype: float64, shape: (1, 8)
         """
         from .ts_group import TsGroup
 
+        # check epochs
         if epochs is None:
             epochs = self.time_support
-
+        elif not isinstance(epochs, IntervalSet):
+            raise TypeError("epochs should be an IntervalSet.")
         data = self.restrict(epochs)
+
+        # check return_prop
+        if return_prop != 1 and return_prop != 0 and not isinstance(return_prop, bool):
+            raise TypeError("return_prop should be a boolean.")
+
         return TsGroup(
             {
                 col: Tsd(t=data.t, d=data.values[:, i], time_support=epochs).find_peaks(
-                    epochs, return_prop, *args
+                    epochs, return_prop, *args, **kwargs
                 )
                 for i, col in enumerate(self.columns)
             },
@@ -3367,7 +3405,7 @@ class Tsd(_BaseTsd):
             group, time_support=self.time_support, bypass_check=True
         )
 
-    def find_peaks(self, epochs=None, return_prop=False, *args):
+    def find_peaks(self, epochs=None, return_prop=False, *args, **kwargs):
         """
         Find peaks based on peak properties.
 
@@ -3419,9 +3457,9 @@ class Tsd(_BaseTsd):
 
         Returns
         -------
-        peaks : Tsd, TsdFrame
+        Tsd, TsdFrame
             The time points and values of the peaks.
-            Peak properties are included as columns if `return_prop=True`.
+            Peak properties are included as columns if ``return_prop=True``.
 
         Examples
         --------
@@ -3436,14 +3474,39 @@ class Tsd(_BaseTsd):
         1.6         0.999574
         7.9         0.998941
         dtype: float64, shape: (2,)
+
+        You can set various requirements for finding peaks, for example a minimum width:
+
+        >>> peaks = tsd.find_peaks(width=21)
+        >>> peaks
+        Time (s)
+        ----------  --------
+        7.9         0.998941
+        dtype: float64, shape: (1,)
+
+        If you further want the peak properties returned, you can pass `return_prop=True`:
+
+        >>> peaks = tsd.find_peaks(return_prop=True, width=21)
+        >>> peaks
+        Time (s)      peak_value    prominences    left_bases    right_bases    widths  ...
+        ----------  ------------  -------------  ------------  -------------  --------  -----
+        7.9             0.998941        1.45648            47             99   25.9266  ...
+        dtype: float64, shape: (1, 8)
         """
         from scipy.signal import find_peaks
 
+        # check epochs
         if epochs is None:
             epochs = self.time_support
-
+        elif not isinstance(epochs, IntervalSet):
+            raise TypeError("epochs should be an IntervalSet.")
         data = self.restrict(epochs)
-        peaks, properties = find_peaks(data.values, *args)
+
+        # check return_prop
+        if return_prop != 1 and return_prop != 0 and not isinstance(return_prop, bool):
+            raise TypeError("return_prop should be a boolean.")
+
+        peaks, properties = find_peaks(data.values, *args, **kwargs)
         times = data.t[peaks]
         values = data.values[peaks]
 

--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -2295,7 +2295,7 @@ class TsdFrame(_BaseTsd, _MetadataMixin):
 
         return TsGroup(
             {
-                col: Tsd(t=data.t, d=data.values[:, i], time_support=epochs).find_peaks(
+                i: Tsd(t=data.t, d=data.values[:, i], time_support=epochs).find_peaks(
                     epochs, return_prop, *args, **kwargs
                 )
                 for i, col in enumerate(self.columns)

--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -2301,6 +2301,7 @@ class TsdFrame(_BaseTsd, _MetadataMixin):
                 for i, col in enumerate(self.columns)
             },
             time_support=epochs,
+            metadata={"columns": list(self.columns)},
         )
 
     # @add_or_convert_metadata

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -1381,6 +1381,117 @@ class TestTsd:
         derivative = tsd.derivative(ep=ep)
         assert np.all(derivative == expected)
 
+    @pytest.mark.parametrize(
+        "epochs, return_prop, expectation",
+        [
+            # epochs
+            (
+                [0, 1],
+                0,
+                pytest.raises(TypeError, match="epochs should be an IntervalSet."),
+            ),
+            (
+                False,
+                0,
+                pytest.raises(TypeError, match="epochs should be an IntervalSet."),
+            ),
+            (
+                "huh",
+                0,
+                pytest.raises(TypeError, match="epochs should be an IntervalSet."),
+            ),
+            (nap.IntervalSet(0, 1), 0, does_not_raise()),
+            (nap.IntervalSet([0, 3], [2, 4]), 0, does_not_raise()),
+            # return_prop
+            (
+                None,
+                None,
+                pytest.raises(TypeError, match="return_prop should be a boolean."),
+            ),
+            (
+                None,
+                "huh",
+                pytest.raises(TypeError, match="return_prop should be a boolean."),
+            ),
+            (
+                None,
+                2,
+                pytest.raises(TypeError, match="return_prop should be a boolean."),
+            ),
+            (None, 0, does_not_raise()),
+            (None, 1, does_not_raise()),
+            (None, False, does_not_raise()),
+            (None, True, does_not_raise()),
+        ],
+    )
+    def test_find_peaks_type_errors(self, tsd, epochs, return_prop, expectation):
+        with expectation:
+            tsd.find_peaks(epochs=epochs, return_prop=return_prop)
+
+    def test_find_peaks(self, tsd):
+        from scipy.signal import find_peaks
+
+        peaks = tsd.find_peaks()
+        assert isinstance(peaks, nap.Tsd)
+        np.testing.assert_array_almost_equal(peaks.time_support, tsd.time_support)
+
+        expected_peaks = find_peaks(tsd.values)[0]
+        expected_peak_values = tsd.values[expected_peaks]
+        expected_peak_times = tsd.t[expected_peaks]
+
+        np.testing.assert_array_almost_equal(peaks.t, expected_peak_times)
+        np.testing.assert_array_almost_equal(peaks.values, expected_peak_values)
+
+    @pytest.mark.parametrize(
+        "epochs",
+        [
+            nap.IntervalSet(0, 10),
+            nap.IntervalSet([0, 10], [5, 30]),
+            nap.IntervalSet(0, 1000),
+        ],
+    )
+    def test_find_peaks_epochs(self, tsd, epochs):
+        from scipy.signal import find_peaks
+
+        peaks = tsd.find_peaks(epochs=epochs)
+        assert isinstance(peaks, nap.Tsd)
+        np.testing.assert_array_almost_equal(peaks.time_support, epochs)
+
+        data = tsd.restrict(epochs)
+        expected_peaks = find_peaks(data.values)[0]
+        expected_peak_values = data.values[expected_peaks]
+        expected_peak_times = data.t[expected_peaks]
+
+        np.testing.assert_array_almost_equal(peaks.t, expected_peak_times)
+        np.testing.assert_array_almost_equal(peaks.values, expected_peak_values)
+
+    @pytest.mark.parametrize(
+        "kwargs", [{}, {"width": 0.1}, {"width": 0.1, "height": 0.1}]
+    )
+    def test_find_peaks_return_prop(self, tsd, kwargs):
+        from scipy.signal import find_peaks
+
+        peaks = tsd.find_peaks(return_prop=True, **kwargs)
+        assert isinstance(peaks, nap.TsdFrame)
+        np.testing.assert_array_almost_equal(peaks.time_support, tsd.time_support)
+
+        expected_peaks, properties = find_peaks(tsd.values, **kwargs)
+        expected_peak_values = tsd.values[expected_peaks]
+        expected_peak_times = tsd.t[expected_peaks]
+
+        np.testing.assert_array_almost_equal(peaks.t, expected_peak_times)
+        np.testing.assert_array_almost_equal(peaks.values[:, 0], expected_peak_values)
+
+        assert len(peaks.columns) == len(properties) + 1
+        assert all(
+            col == expected_col
+            for col, expected_col in zip(
+                peaks.columns, ["peak_value"] + list(properties.keys())
+            )
+        )
+        for key in properties.keys():
+            np.testing.assert_array_almost_equal(peaks[key], properties[key])
+
 
 ####################################################
 # Test for tsdframe
@@ -1942,6 +2053,53 @@ class TestTsdFrame:
 
         assert isinstance(tsd2, nap.TsdFrame)
         np.testing.assert_array_equal(tsd2.columns, tsdframe.columns)
+
+    @pytest.mark.parametrize(
+        "epochs, return_prop, expectation",
+        [
+            # epochs
+            (
+                [0, 1],
+                0,
+                pytest.raises(TypeError, match="epochs should be an IntervalSet."),
+            ),
+            (
+                False,
+                0,
+                pytest.raises(TypeError, match="epochs should be an IntervalSet."),
+            ),
+            (
+                "huh",
+                0,
+                pytest.raises(TypeError, match="epochs should be an IntervalSet."),
+            ),
+            (nap.IntervalSet(0, 1), 0, does_not_raise()),
+            (nap.IntervalSet([0, 3], [2, 4]), 0, does_not_raise()),
+            # return_prop
+            (
+                None,
+                None,
+                pytest.raises(TypeError, match="return_prop should be a boolean."),
+            ),
+            (
+                None,
+                "huh",
+                pytest.raises(TypeError, match="return_prop should be a boolean."),
+            ),
+            (
+                None,
+                2,
+                pytest.raises(TypeError, match="return_prop should be a boolean."),
+            ),
+            (None, 0, does_not_raise()),
+            (None, 1, does_not_raise()),
+            (None, False, does_not_raise()),
+            (None, True, does_not_raise()),
+        ],
+    )
+    def test_find_peaks_type_errors(self, tsdframe, epochs, return_prop, expectation):
+        with expectation:
+            tsdframe.find_peaks(epochs=epochs, return_prop=return_prop)
 
     # def test_deprecation_warning(self, tsdframe):
     #     columns = tsdframe.columns

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -2101,6 +2101,84 @@ class TestTsdFrame:
         with expectation:
             tsdframe.find_peaks(epochs=epochs, return_prop=return_prop)
 
+    def test_find_peaks(self, tsdframe):
+        from scipy.signal import find_peaks
+
+        peaks = tsdframe.find_peaks()
+        assert isinstance(peaks, nap.TsGroup)
+        assert len(peaks) == len(tsdframe.columns)
+        np.testing.assert_array_almost_equal(peaks.time_support, tsdframe.time_support)
+
+        for i, k in enumerate(tsdframe.columns):
+            assert isinstance(peaks[i], nap.Tsd)
+
+            expected_peaks = find_peaks(tsdframe.values[:, i])[0]
+            expected_peak_values = tsdframe.values[expected_peaks, i]
+            expected_peak_times = tsdframe.t[expected_peaks]
+
+            np.testing.assert_array_almost_equal(peaks[i].values, expected_peak_values)
+            np.testing.assert_array_almost_equal(peaks[i].t, expected_peak_times)
+
+    @pytest.mark.parametrize(
+        "epochs",
+        [
+            nap.IntervalSet(0, 10),
+            nap.IntervalSet([0, 10], [5, 30]),
+            nap.IntervalSet(0, 1000),
+        ],
+    )
+    def test_find_peaks_epochs(self, tsdframe, epochs):
+        from scipy.signal import find_peaks
+
+        peaks = tsdframe.find_peaks(epochs=epochs)
+        assert isinstance(peaks, nap.TsGroup)
+        assert len(peaks) == len(tsdframe.columns)
+        np.testing.assert_array_almost_equal(peaks.time_support, epochs)
+
+        data = tsdframe.restrict(epochs)
+        for i, k in enumerate(tsdframe.columns):
+            assert isinstance(peaks[i], nap.Tsd)
+
+            expected_peaks = find_peaks(data.values[:, i])[0]
+            expected_peak_values = data.values[expected_peaks, i]
+            expected_peak_times = data.t[expected_peaks]
+
+            np.testing.assert_array_almost_equal(peaks[i].values, expected_peak_values)
+            np.testing.assert_array_almost_equal(peaks[i].t, expected_peak_times)
+
+    @pytest.mark.parametrize(
+        "kwargs", [{}, {"width": 0.1}, {"width": 0.1, "height": 0.1}]
+    )
+    def test_find_peaks_return_prop(self, tsdframe, kwargs):
+        from scipy.signal import find_peaks
+
+        peaks = tsdframe.find_peaks(return_prop=True, **kwargs)
+        assert isinstance(peaks, nap.TsGroup)
+        assert len(peaks) == len(tsdframe.columns)
+        np.testing.assert_array_almost_equal(peaks.time_support, tsdframe.time_support)
+
+        for i, k in enumerate(tsdframe.columns):
+            assert isinstance(peaks[i], nap.TsdFrame)
+
+            expected_peaks, properties = find_peaks(tsdframe.values[:, i], **kwargs)
+            expected_peak_values = tsdframe.values[expected_peaks, i]
+            expected_peak_times = tsdframe.t[expected_peaks]
+
+            np.testing.assert_array_almost_equal(
+                peaks[i].values[:, 0], expected_peak_values
+            )
+            np.testing.assert_array_almost_equal(peaks[i].t, expected_peak_times)
+
+            assert len(peaks[i].columns) == len(properties) + 1
+            assert all(
+                col == expected_col
+                for col, expected_col in zip(
+                    peaks[i].columns, ["peak_value"] + list(properties.keys())
+                )
+            )
+            for key in properties.keys():
+                np.testing.assert_array_almost_equal(peaks[i][key], properties[key])
+
     # def test_deprecation_warning(self, tsdframe):
     #     columns = tsdframe.columns
     #     # warning using loc


### PR DESCRIPTION
This PR adds a `find_peaks` method to `Tsd` and `TsdFrame`.
The method mostly wraps `scipy.signal.find_peaks`, but ensures correct epochs and Pynapple formatting.

## Usage

### For `Tsd`: 
```
        >>> import pynapple as nap
        >>> import numpy as np
        >>> times = np.arange(0, 10, 0.1)
        >>> tsd = nap.Tsd(t=times, d=np.sin(times))
        >>> peaks = tsd.find_peaks()
        >>> peaks
        Time (s)
        ----------  --------
        1.6         0.999574
        7.9         0.998941
        dtype: float64, shape: (2,)
```
You can set various requirements for finding peaks, for example a minimum width (these are just passed to `scipy.signal.find_peaks`):
```
        >>> peaks = tsd.find_peaks(width=21)
        >>> peaks
        Time (s)
        ----------  --------
        7.9         0.998941
        dtype: float64, shape: (1,)
```
If you further want the peak properties returned, you can pass `return_prop=True`:
```
        >>> peaks = tsd.find_peaks(return_prop=True, width=21)
        >>> peaks
        Time (s)      peak_value    prominences    left_bases    right_bases    widths  ...
        ----------  ------------  -------------  ------------  -------------  --------  -----
        7.9             0.998941        1.45648            47             99   25.9266  ...
        dtype: float64, shape: (1, 8)

```

### For `TsdFrame`:
It works similarly, but we return a `TsGroup` containing the same outputs per column:
```        
        >>> import pynapple as nap
        >>> import numpy as np
        >>> times = np.arange(0, 10, 0.1)
        >>> tsdframe = nap.TsdFrame(t=times, d=np.stack([np.sin(times), np.cos(times)], axis=1))
        >>> peaks = tsdframe.find_peaks()
        >>> peaks
          Index     rate
        -------  -------
              0  0.20202
              1  0.10101
        >>> peaks[0]
        Time (s)
        ----------  --------
        1.6         0.999574
        7.9         0.998941
        dtype: float64, shape: (2,)
```
You can again set various requirements for finding peaks, for example a minimum width:
```
        >>> peaks = tsdframe.find_peaks(width=21)
        >>> peaks
          Index     rate
        -------  -------
              0  0.10101
              1  0.10101
        >>> peaks[0]
        Time (s)
        ----------  --------
        7.9         0.998941
        dtype: float64, shape: (1,)
```
If you want the peak properties returned, you can again pass `return_prop=True`:
```
        >>> peaks = tsdframe.find_peaks(return_prop=True, width=21)
        >>> peaks
          Index     rate
        -------  -------
              0  0.10101
              1  0.10101
        >>> peaks[0]
        Time (s)      peak_value    prominences    left_bases    right_bases    widths  ...
        ----------  ------------  -------------  ------------  -------------  --------  -----
        7.9             0.998941        1.45648            47             99   25.9266  ...
        dtype: float64, shape: (1, 8)
```

## Documentation
Both methods have docstrings, including examples.
In a future PR we will use these methods in the tutorials, but for the moment I don't think they need a user guide.

## Testing
Adds thorough testing for the `find_peaks` methods for both classes, checking input/output types, correct peak extraction, metadata, etc.

## Related issues
#550 #584 

## Questions for reviewers

In the case of a `TsdFrame` we return a `TsGroup` containing entries per column.
However, `TsGroup` requires integer keys, whereas `TsdFrame` columns can be strings. 
The current implementation sets the `TsGroup` keys to be indices starting from 0.
That might not be very intuitive for the user if they do have string columns.

A simplification would be to return a `dict` instead of a `TsGroup`, but then we won't be tracking the `time_support`.