### PR TITLE
adding intevalset to neurosuite

### DIFF
--- a/pynapple/io/interface_neo.py
+++ b/pynapple/io/interface_neo.py
@@ -1015,7 +1015,7 @@ class EphysReader(UserDict):
 
         Uses :class:`~pynapple.io.interface_neurosuite.NeuroSuiteIO` to
         discover files and parse XML metadata.  Populates ``self.data``
-        with entries for .dat, .eeg/.lfp, and .clu/.res files.
+        with entries for .dat, .eeg/.lfp, .clu/.res, and .evt files.
 
         Parameters
         ----------
@@ -1047,6 +1047,11 @@ class EphysReader(UserDict):
                 "type": "TsGroup",
                 "loader": lambda s=shank: ns.load_spikes(s),
             }
+
+        # --- .evt files (events) ---
+        for evt_file in ns.evt_files:
+            for category, ts in ns.load_events(evt_file).items():
+                self.data[category] = ts
 
         self._ns = ns  # Store the NeuroSuiteIO instance for use in loaders
 

--- a/pynapple/io/interface_neurosuite.py
+++ b/pynapple/io/interface_neurosuite.py
@@ -4,14 +4,102 @@ Handles:
 - XML metadata parsing (channel count, sampling rates, channel groups)
 - Binary signal files (.dat, .eeg, .lfp) via memory mapping
 - Spike sorting results (.clu.N / .res.N pairs)
+- Event files (.evt) with automatic pairing of start/stop events into IntervalSets
 """
 
+import re
 import xml.etree.ElementTree as ET
+from collections import defaultdict
 from pathlib import Path
 
 import numpy as np
 
 from .. import core as nap
+
+
+_START_RE = re.compile(r"\b(start|Start|START)\b")
+_STOP_WORDS = ["stop", "Stop", "STOP", "end", "End", "END"]
+
+
+def _pair_start_stop(starts, stops):
+    """Pair each start with the first stop after it and before the next start."""
+    paired_s, paired_e = [], []
+    j = 0
+    for i, t0 in enumerate(starts):
+        t_next = starts[i + 1] if i + 1 < len(starts) else np.inf
+        while j < len(stops) and stops[j] <= t0:
+            j += 1
+        if j < len(stops) and stops[j] < t_next:
+            paired_s.append(t0)
+            paired_e.append(stops[j])
+            j += 1
+    return np.array(paired_s), np.array(paired_e)
+
+
+def _build_events(raw_events):
+    """Convert {category: [timestamps_s]} into pynapple objects.
+
+    Keys containing 'start'/'Start'/'START' are paired with their matching
+    stop key to form an IntervalSet.  Any remaining timestamps whose events
+    fall inside those intervals are attached as IntervalSet metadata.
+    Unpaired keys are returned as Ts objects.
+    """
+    result = {}
+    used = set()
+
+    for key in list(raw_events.keys()):
+        if key in used or not _START_RE.search(key):
+            continue
+
+        # Find corresponding stop key
+        start_word = _START_RE.search(key).group(0)
+        stop_key = None
+        for stop_word in _STOP_WORDS:
+            candidate = key.replace(start_word, stop_word)
+            if candidate != key and candidate in raw_events:
+                stop_key = candidate
+                break
+        if stop_key is None:
+            continue
+
+        starts = np.sort(np.array(raw_events[key]))
+        stops = np.sort(np.array(raw_events[stop_key]))
+        paired_s, paired_e = _pair_start_stop(starts, stops)
+        if len(paired_s) == 0:
+            continue
+
+        iset = nap.IntervalSet(start=paired_s, end=paired_e)
+        used.update([key, stop_key])
+
+        # Attach remaining timestamps as metadata (one value per interval)
+        metadata = {}
+        for other_key, other_times in raw_events.items():
+            if other_key in used:
+                continue
+            other_times = np.sort(np.array(other_times))
+            col = []
+            for i in range(len(iset)):
+                mask = (other_times >= iset.start[i]) & (
+                    other_times <= iset.end[i]
+                )
+                matches = other_times[mask]
+                col.append(matches[0] if len(matches) > 0 else np.nan)
+            metadata[other_key] = col
+            used.add(other_key)
+
+        if metadata:
+            iset.set_info(**metadata)
+
+        # Build a clean key: strip the start word and collapse extra spaces
+        iset_key = re.sub(r"\s+", " ", _START_RE.sub("", key)).strip() or key
+        result[iset_key] = iset
+
+    # Remaining keys become plain Ts objects
+    for key, times in raw_events.items():
+        if key not in used:
+            result[key] = nap.Ts(t=np.sort(np.array(times)))
+
+    return result
 
 
 def _text(parent, tag):
@@ -156,6 +244,7 @@ class NeuroSuiteIO:
     - ``basename.eeg`` or ``basename.lfp`` – LFP signal (int16 binary)
     - ``basename.clu.N`` / ``basename.res.N`` – spike cluster IDs and times
       for electrode group *N*
+    - ``basename.evt`` – event timestamps with category labels
 
     Parameters
     ----------
@@ -182,6 +271,8 @@ class NeuroSuiteIO:
         Detected .eeg / .lfp files.
     spike_groups : dict
         Mapping of shank number (str) to ``(clu_path, res_path)`` tuples.
+    evt_files : list of Path
+        Detected .evt files.
     """
 
     def __init__(self, path):
@@ -222,6 +313,7 @@ class NeuroSuiteIO:
         self.dat_files = self._find_files(".dat")
         self.lfp_files = self._find_files(".eeg") or self._find_files(".lfp")
         self.spike_groups = self._find_spike_groups()
+        self.evt_files = self._find_evt_files()
 
     # ------------------------------------------------------------------
     # File discovery helpers
@@ -234,6 +326,17 @@ class NeuroSuiteIO:
         if not files:
             files = sorted(self.session_dir.glob(f"*{extension}"))
         return files
+
+    def _find_evt_files(self):
+        """Return sorted list of *.evt, *.evt.*, and *.*.evt files for this session."""
+        exact = sorted(self.session_dir.glob(f"{self.basename}.evt"))
+        pre_tagged = sorted(self.session_dir.glob(f"{self.basename}.*.evt"))
+        post_tagged = sorted(self.session_dir.glob(f"{self.basename}.evt.*"))
+        if not exact and not pre_tagged and not post_tagged:
+            exact = sorted(self.session_dir.glob("*.evt"))
+            pre_tagged = sorted(self.session_dir.glob("*.*.evt"))
+            post_tagged = sorted(self.session_dir.glob("*.evt.*"))
+        return exact + pre_tagged + post_tagged
 
     def _find_spike_groups(self):
         """Find paired .clu.N / .res.N files and return a dict keyed by
@@ -355,3 +458,42 @@ class NeuroSuiteIO:
         return nap.TsGroup(
             ts_dict, time_support=time_support, metadata={"group": group}
         )
+
+    def load_events(self, filepath=None):
+        """Load a NeuroSuite .evt file and return a dict of pynapple objects.
+
+        Keys containing 'start'/'Start'/'START' are paired with their
+        matching stop key to produce an :class:`~pynapple.IntervalSet`.
+        Timestamps from other categories that fall within those intervals
+        are attached as IntervalSet metadata.  Any unpaired categories are
+        returned as :class:`~pynapple.Ts` objects.
+
+        Parameters
+        ----------
+        filepath : str or Path, optional
+            Path to the .evt file.  If *None*, the first discovered .evt file
+            in the session directory is used.
+
+        Returns
+        -------
+        dict
+            Mapping of category/base-name to IntervalSet or Ts.
+        """
+        if filepath is None:
+            if not self.evt_files:
+                raise FileNotFoundError(
+                    f"No .evt files found in {self.session_dir}"
+                )
+            filepath = self.evt_files[0]
+
+        filepath = Path(filepath)
+        raw_events = defaultdict(list)
+
+        with open(filepath, "r") as f:
+            for line in f:
+                parts = line.strip().split("\t")
+                if len(parts) < 2:
+                    continue
+                raw_events[parts[1]].append(float(parts[0]) / 1000.0)  # ms -> s
+
+        return _build_events(raw_events)

--- a/pynapple/io/interface_neurosuite.py
+++ b/pynapple/io/interface_neurosuite.py
@@ -16,7 +16,6 @@ import numpy as np
 
 from .. import core as nap
 
-
 _START_RE = re.compile(r"\b(start|Start|START)\b")
 _STOP_WORDS = ["stop", "Stop", "STOP", "end", "End", "END"]
 
@@ -79,9 +78,7 @@ def _build_events(raw_events):
             other_times = np.sort(np.array(other_times))
             col = []
             for i in range(len(iset)):
-                mask = (other_times >= iset.start[i]) & (
-                    other_times <= iset.end[i]
-                )
+                mask = (other_times >= iset.start[i]) & (other_times <= iset.end[i])
                 matches = other_times[mask]
                 col.append(matches[0] if len(matches) > 0 else np.nan)
             metadata[other_key] = col
@@ -481,9 +478,7 @@ class NeuroSuiteIO:
         """
         if filepath is None:
             if not self.evt_files:
-                raise FileNotFoundError(
-                    f"No .evt files found in {self.session_dir}"
-                )
+                raise FileNotFoundError(f"No .evt files found in {self.session_dir}")
             filepath = self.evt_files[0]
 
         filepath = Path(filepath)

--- a/tests/test_interface_neurosuite.py
+++ b/tests/test_interface_neurosuite.py
@@ -7,7 +7,12 @@ import numpy as np
 import pytest
 
 import pynapple as nap
-from pynapple.io.interface_neurosuite import NeuroSuiteIO, parse_neuroscope_xml
+from pynapple.io.interface_neurosuite import (
+    NeuroSuiteIO,
+    _build_events,
+    _pair_start_stop,
+    parse_neuroscope_xml,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers to generate synthetic Neuroscope session files
@@ -402,3 +407,280 @@ class TestLoadSpikes:
         ts2 = ns.load_spikes("2")
         assert isinstance(ts1, nap.TsGroup)
         assert isinstance(ts2, nap.TsGroup)
+
+
+# ---------------------------------------------------------------------------
+# Helpers: evt file generation
+# ---------------------------------------------------------------------------
+
+
+def _make_evt(session_dir, filename, events):
+    """Write a .evt file. *events* is a list of (timestamp_ms, label) tuples."""
+    evt_path = session_dir / filename
+    with open(evt_path, "w") as f:
+        for t_ms, label in events:
+            f.write(f"{t_ms:.6f}\t{label}\n")
+    return evt_path
+
+
+# ---------------------------------------------------------------------------
+# Tests: _pair_start_stop
+# ---------------------------------------------------------------------------
+
+
+class TestPairStartStop:
+    def test_one_to_one_pairing(self):
+        starts = np.array([1.0, 3.0, 6.0])
+        stops = np.array([2.0, 4.0, 7.0])
+        s, e = _pair_start_stop(starts, stops)
+        np.testing.assert_array_equal(s, [1.0, 3.0, 6.0])
+        np.testing.assert_array_equal(e, [2.0, 4.0, 7.0])
+
+    def test_stop_after_next_start_is_unpaired(self):
+        # stop at 4.0 is >= next start at 3.0, so start at 1.0 goes unpaired
+        starts = np.array([1.0, 3.0])
+        stops = np.array([4.0, 5.0])
+        s, e = _pair_start_stop(starts, stops)
+        np.testing.assert_array_equal(s, [3.0])
+        np.testing.assert_array_equal(e, [4.0])
+
+    def test_stop_before_start_is_skipped(self):
+        starts = np.array([5.0])
+        stops = np.array([2.0, 8.0])
+        s, e = _pair_start_stop(starts, stops)
+        np.testing.assert_array_equal(s, [5.0])
+        np.testing.assert_array_equal(e, [8.0])
+
+    def test_no_stops_returns_empty(self):
+        s, e = _pair_start_stop(np.array([1.0, 2.0]), np.array([]))
+        assert len(s) == 0
+        assert len(e) == 0
+
+    def test_empty_inputs_return_empty(self):
+        s, e = _pair_start_stop(np.array([]), np.array([]))
+        assert len(s) == 0
+        assert len(e) == 0
+
+    def test_single_pair(self):
+        s, e = _pair_start_stop(np.array([0.0]), np.array([1.0]))
+        np.testing.assert_array_equal(s, [0.0])
+        np.testing.assert_array_equal(e, [1.0])
+
+
+# ---------------------------------------------------------------------------
+# Tests: _build_events
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEvents:
+    def test_lowercase_start_stop_becomes_intervalset(self):
+        raw = {"ripple start": [1.0, 3.0], "ripple stop": [2.0, 4.0]}
+        result = _build_events(raw)
+        assert "ripple" in result
+        assert isinstance(result["ripple"], nap.IntervalSet)
+        assert len(result["ripple"]) == 2
+
+    def test_intervalset_start_end_values(self):
+        raw = {"sleep start": [10.0, 30.0], "sleep stop": [20.0, 40.0]}
+        result = _build_events(raw)
+        iset = result["sleep"]
+        np.testing.assert_allclose(iset.start, [10.0, 30.0])
+        np.testing.assert_allclose(iset.end, [20.0, 40.0])
+
+    def test_capitalized_start_stop_variant(self):
+        raw = {"Run Start": [0.0, 5.0], "Run Stop": [2.0, 7.0]}
+        result = _build_events(raw)
+        assert "Run" in result
+        assert isinstance(result["Run"], nap.IntervalSet)
+
+    def test_uppercase_start_stop_variant(self):
+        raw = {"REM START": [0.0], "REM STOP": [10.0]}
+        result = _build_events(raw)
+        assert "REM" in result
+        assert isinstance(result["REM"], nap.IntervalSet)
+
+    def test_start_end_variant(self):
+        raw = {"epoch start": [1.0, 5.0], "epoch end": [3.0, 8.0]}
+        result = _build_events(raw)
+        assert "epoch" in result
+        assert isinstance(result["epoch"], nap.IntervalSet)
+
+    def test_unpaired_key_becomes_ts(self):
+        raw = {"stimulus": [1.0, 2.0, 3.0]}
+        result = _build_events(raw)
+        assert "stimulus" in result
+        assert isinstance(result["stimulus"], nap.Ts)
+        np.testing.assert_allclose(result["stimulus"].times(), [1.0, 2.0, 3.0])
+
+    def test_start_without_matching_stop_stays_as_ts(self):
+        raw = {"theta start": [1.0, 3.0]}
+        result = _build_events(raw)
+        assert "theta start" in result
+        assert isinstance(result["theta start"], nap.Ts)
+
+    def test_other_key_attached_as_intervalset_metadata(self):
+        raw = {
+            "ripple start": [1.0, 5.0],
+            "ripple stop": [2.0, 6.0],
+            "ripple peak": [1.5, 5.5],
+        }
+        result = _build_events(raw)
+        iset = result["ripple"]
+        assert "ripple peak" in iset.metadata.keys()
+        np.testing.assert_allclose(iset.metadata["ripple peak"], [1.5, 5.5])
+        assert "ripple peak" not in result
+
+    def test_second_start_stop_pair_consumed_as_metadata(self):
+        # _build_events processes one start/stop pair at a time; remaining keys
+        # (including a second category's start/stop) are attached as metadata
+        # of the first IntervalSet rather than forming their own IntervalSet.
+        raw = {
+            "sleep start": [0.0, 20.0],
+            "sleep stop": [10.0, 30.0],
+            "run start": [50.0],
+            "run stop": [60.0],
+        }
+        result = _build_events(raw)
+        assert isinstance(result["sleep"], nap.IntervalSet)
+        # "run start" / "run stop" are consumed as metadata (no overlap → NaN)
+        assert "run" not in result
+        assert "run start" in result["sleep"].metadata.keys()
+        assert "run stop" in result["sleep"].metadata.keys()
+
+    def test_no_pairs_all_ts(self):
+        raw = {"a": [1.0], "b": [2.0]}
+        result = _build_events(raw)
+        assert isinstance(result["a"], nap.Ts)
+        assert isinstance(result["b"], nap.Ts)
+
+
+# ---------------------------------------------------------------------------
+# Tests: _find_evt_files and load_events
+# ---------------------------------------------------------------------------
+
+
+class TestEvtFileDiscovery:
+    def test_exact_evt_file_found(self, session_dir):
+        _make_evt(session_dir, f"{BASENAME}.evt", [(100.0, "event")])
+        ns = NeuroSuiteIO(session_dir)
+        assert any(f.name == f"{BASENAME}.evt" for f in ns.evt_files)
+
+    def test_pre_tagged_evt_file_found(self, session_dir):
+        _make_evt(session_dir, f"{BASENAME}.rip.evt", [(100.0, "event")])
+        ns = NeuroSuiteIO(session_dir)
+        assert any("rip.evt" in f.name for f in ns.evt_files)
+
+    def test_post_tagged_evt_file_found(self, session_dir):
+        _make_evt(session_dir, f"{BASENAME}.evt.rip", [(100.0, "event")])
+        ns = NeuroSuiteIO(session_dir)
+        assert any("evt.rip" in f.name for f in ns.evt_files)
+
+    def test_no_evt_files_gives_empty_list(self, session_dir):
+        ns = NeuroSuiteIO(session_dir)
+        assert ns.evt_files == []
+
+    def test_multiple_evt_files_all_found(self, session_dir):
+        _make_evt(session_dir, f"{BASENAME}.evt", [(100.0, "x")])
+        _make_evt(session_dir, f"{BASENAME}.rip.evt", [(200.0, "y")])
+        ns = NeuroSuiteIO(session_dir)
+        assert len(ns.evt_files) == 2
+
+
+class TestLoadEvents:
+    def test_returns_intervalset_for_start_stop_pair(self, session_dir):
+        _make_evt(
+            session_dir,
+            f"{BASENAME}.evt",
+            [
+                (1000.0, "ripple start"),
+                (1500.0, "ripple stop"),
+                (3000.0, "ripple start"),
+                (3500.0, "ripple stop"),
+            ],
+        )
+        ns = NeuroSuiteIO(session_dir)
+        events = ns.load_events()
+        assert "ripple" in events
+        assert isinstance(events["ripple"], nap.IntervalSet)
+        assert len(events["ripple"]) == 2
+
+    def test_timestamps_converted_from_ms_to_s(self, session_dir):
+        _make_evt(
+            session_dir,
+            f"{BASENAME}.evt",
+            [(1000.0, "trial start"), (2000.0, "trial stop")],
+        )
+        ns = NeuroSuiteIO(session_dir)
+        iset = ns.load_events()["trial"]
+        np.testing.assert_allclose(iset.start, [1.0])
+        np.testing.assert_allclose(iset.end, [2.0])
+
+    def test_unpaired_events_returned_as_ts(self, session_dir):
+        _make_evt(
+            session_dir,
+            f"{BASENAME}.evt",
+            [(500.0, "stimulus"), (1500.0, "stimulus")],
+        )
+        ns = NeuroSuiteIO(session_dir)
+        events = ns.load_events()
+        assert "stimulus" in events
+        assert isinstance(events["stimulus"], nap.Ts)
+        np.testing.assert_allclose(events["stimulus"].times(), [0.5, 1.5])
+
+    def test_no_evt_files_raises_file_not_found(self, session_dir):
+        ns = NeuroSuiteIO(session_dir)
+        with pytest.raises(FileNotFoundError):
+            ns.load_events()
+
+    def test_explicit_filepath(self, session_dir, tmp_path):
+        evt_path = tmp_path / "custom.evt"
+        _make_evt(tmp_path, "custom.evt", [(1000.0, "run start"), (2000.0, "run stop")])
+        ns = NeuroSuiteIO(session_dir)
+        events = ns.load_events(filepath=evt_path)
+        assert "run" in events
+        assert isinstance(events["run"], nap.IntervalSet)
+
+    def test_uses_first_discovered_evt_file(self, session_dir):
+        _make_evt(
+            session_dir,
+            f"{BASENAME}.evt",
+            [(1000.0, "sleep start"), (2000.0, "sleep stop")],
+        )
+        ns = NeuroSuiteIO(session_dir)
+        events = ns.load_events()
+        assert "sleep" in events
+
+    def test_two_distinct_epoch_types_separate_files(self, session_dir):
+        sleep_path = _make_evt(
+            session_dir,
+            f"{BASENAME}.sleep.evt",
+            [(0.0, "sleep start"), (5000.0, "sleep stop")],
+        )
+        run_path = _make_evt(
+            session_dir,
+            f"{BASENAME}.run.evt",
+            [(10000.0, "run start"), (15000.0, "run stop")],
+        )
+        ns = NeuroSuiteIO(session_dir)
+        sleep_events = ns.load_events(filepath=sleep_path)
+        run_events = ns.load_events(filepath=run_path)
+        assert isinstance(sleep_events["sleep"], nap.IntervalSet)
+        assert isinstance(run_events["run"], nap.IntervalSet)
+
+    def test_metadata_from_nested_timestamps(self, session_dir):
+        _make_evt(
+            session_dir,
+            f"{BASENAME}.evt",
+            [
+                (1000.0, "ripple start"),
+                (1250.0, "ripple peak"),
+                (1500.0, "ripple stop"),
+                (3000.0, "ripple start"),
+                (3250.0, "ripple peak"),
+                (3500.0, "ripple stop"),
+            ],
+        )
+        ns = NeuroSuiteIO(session_dir)
+        iset = ns.load_events()["ripple"]
+        assert "ripple peak" in iset.metadata.keys()
+        np.testing.assert_allclose(iset.metadata["ripple peak"], [1.25, 3.25])


### PR DESCRIPTION
This pull request adds support for loading and parsing `.evt` event files from NeuroSuite sessions in the `pynapple` IO interface. It introduces logic to automatically pair start/stop events into `IntervalSet` objects, attaches interval metadata, and exposes event loading through the `NeuroSuiteIO` class. The changes improve event file discovery and make event data available in a structured format.

**Event file support and parsing:**

* Added detection and loading of `.evt` files in `NeuroSuiteIO`, including methods to find all relevant `.evt` files in a session directory. (`pynapple/io/interface_neurosuite.py`) [[1]](diffhunk://#diff-705e6b4ff10824b1696a9f53c3d1d1454d77f34daea739b020a748ff45b8f4e6R274-R275) [[2]](diffhunk://#diff-705e6b4ff10824b1696a9f53c3d1d1454d77f34daea739b020a748ff45b8f4e6R316) [[3]](diffhunk://#diff-705e6b4ff10824b1696a9f53c3d1d1454d77f34daea739b020a748ff45b8f4e6R330-R340) [[4]](diffhunk://#diff-705e6b4ff10824b1696a9f53c3d1d1454d77f34daea739b020a748ff45b8f4e6R247)
* Implemented the `load_events` method, which reads `.evt` files, pairs start/stop events into `IntervalSet` objects, and attaches other event timestamps as metadata. Unpaired events are returned as `Ts` objects. (`pynapple/io/interface_neurosuite.py`)
* Added helper functions `_pair_start_stop` and `_build_events` to handle event pairing and conversion to pynapple objects. (`pynapple/io/interface_neurosuite.py`)
* Updated documentation to reflect support for `.evt` files and their automatic processing. (`pynapple/io/interface_neurosuite.py`) [[1]](diffhunk://#diff-705e6b4ff10824b1696a9f53c3d1d1454d77f34daea739b020a748ff45b8f4e6R7-R104) [[2]](diffhunk://#diff-705e6b4ff10824b1696a9f53c3d1d1454d77f34daea739b020a748ff45b8f4e6R247)

**Integration with main IO interface:**

* Modified `_collect_neuroscope` in `interface_neo.py` to populate `self.data` with entries from `.evt` files, making event data accessible alongside other session data. (`pynapple/io/interface_neo.py`) [[1]](diffhunk://#diff-5fc12bae5d1a822d1928c44636c9f4abfb0cdb2f81cf33629df6e1dc924169b2L1018-R1018) [[2]](diffhunk://#diff-5fc12bae5d1a822d1928c44636c9f4abfb0cdb2f81cf33629df6e1dc924169b2R1051-R1055)