### PR TITLE
adding link to pynaviz

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -18,9 +18,6 @@ pynapple: python neural analysis package
    GPU acceleration <pynajax>
    Citing <citing>
 
-
-|
-
 .. grid:: 1 1 2 2
 
    .. grid-item::
@@ -56,6 +53,12 @@ pynapple: python neural analysis package
             :shadow:
 
             Citing
+
+         .. button-link:: https://pynapple-org.github.io/pynaviz/
+            :color: primary
+            :shadow:
+
+            Visualization (pynaviz)
 
 
 .. grid:: 1 1 6 6


### PR DESCRIPTION
This pull request updates the main documentation page to add a prominent link to the visualization tool, `pynaviz`, and makes a small formatting cleanup.

Documentation improvements:

* Added a primary button link to the `pynaviz` visualization tool in the documentation homepage for easier access to visualization features.

Formatting cleanup:

* Removed an unnecessary vertical bar and blank lines for improved readability in the documentation index.