### PR TITLE
Dev

### DIFF
--- a/doc/releases.md
+++ b/doc/releases.md
@@ -1,5 +1,14 @@
 # Releases
 
+### 0.11.2 (2026-05-13)
+
+- Fixed out-of-bounds memory access in `jitrestrict`, `jitrestrict_with_count`, `jitin_interval`, `jitremove_nan`, `jitthreshold`, and `jitunion_isets` when called with empty time arrays or empty epoch sets. With Numba JIT enabled these manifested as random crashes or segfaults; with JIT disabled they raised `IndexError`.
+- Fixed missing `k < m` bounds guard in `jitrestrict_with_count` and `jitin_interval`, which could cause an out-of-bounds read when all epoch ends precede the first timestamp.
+- Fixed `jitthreshold` producing an out-of-bounds access when the input contains a single time point.
+- Fixed undefined `nan_cond` variable in `jitvaluefrom` when an epoch contains exactly one target timestamp and mode is `before` or `closest`, which could silently return wrong results instead of `NaN`.
+- Fixed `compute_perievent` crashing on `TsGroup` inputs when any event has no spikes within the requested window.
+
+
 ### 0.11.1 (2026-05-06)
 
 - New `signal` module exposing `apply_hilbert_transform`, `compute_hilbert_envelope`, and `compute_hilbert_phase` for computing the Hilbert transform, signal envelope, and instantaneous phase of time series.

--- a/pynapple/core/_jitted_functions.py
+++ b/pynapple/core/_jitted_functions.py
@@ -11,6 +11,9 @@ def jitrestrict(time_array, starts, ends):
     m = len(starts)
     ix = np.zeros(n, dtype=np.int64)
 
+    if n == 0 or m == 0:
+        return np.empty(0, dtype=np.int64)
+
     k = 0
     t = 0
     x = 0
@@ -52,11 +55,14 @@ def jitrestrict_with_count(time_array, starts, ends, dtype=np.int64):
     ix = np.zeros(n, dtype=np.int64)
     count = np.zeros(m, dtype=dtype)
 
+    if n == 0 or m == 0:
+        return np.empty(0, dtype=np.int64), np.zeros(m, dtype=dtype)
+
     k = 0
     t = 0
     x = 0
 
-    while ends[k] < time_array[t]:
+    while k < m and ends[k] < time_array[t]:
         k += 1
 
     while k < m:
@@ -174,6 +180,10 @@ def jitvaluefrom(
                         if mode == 2:
                             new_interval = time_target_array[i - 1] - time_array[t]
                             nan_cond = new_interval < 0
+                        elif mode == 0:
+                            nan_cond = interval > 0
+                        else:
+                            nan_cond = False
                         if nan_cond:
                             idx[t] = np.nan
                     i -= 1  # Revert to the last valid index
@@ -241,10 +251,13 @@ def jitin_interval(time_array, starts, ends):
     m = len(starts)
     data = np.ones(n, dtype=np.float64) * np.nan
 
+    if n == 0 or m == 0:
+        return data
+
     k = 0
     t = 0
 
-    while ends[k] < time_array[t]:
+    while k < m and ends[k] < time_array[t]:
         k += 1
 
     while k < m:
@@ -280,6 +293,9 @@ def jitremove_nan(time_array, index_nan):
     n = len(time_array)
     ix_start = np.zeros(n, dtype=np.bool_)
     ix_end = np.zeros(n, dtype=np.bool_)
+
+    if n == 0:
+        return time_array[ix_start], time_array[ix_end]
 
     if not index_nan[0]:  # First start
         ix_start[0] = True
@@ -324,12 +340,21 @@ def jitthreshold(time_array, data_array, starts, ends, thr, method="above"):
     new_start = np.zeros(n, dtype=np.float64)
     new_end = np.zeros(n, dtype=np.float64)
 
-    while time_array[t] < starts[k]:
+    if n == 0:
+        return (time_array[ix], data_array[ix], new_start[ix_start], new_end[ix_end])
+
+    while k < len(starts) and time_array[t] < starts[k]:
         k += 1
 
     if ix[t]:
         ix_start[t] = 1
         new_start[t] = time_array[t]
+
+    if n == 1:
+        if ix[t]:
+            ix_end[t] = 1
+            new_end[t] = time_array[t]
+        return (time_array[ix], data_array[ix], new_start[ix_start], new_end[ix_end])
 
     t += 1
 
@@ -701,6 +726,9 @@ def jitunion_isets(starts, ends):
     n = starts.shape[0]
     new_start = np.zeros(n, dtype=np.float64)
     new_end = np.zeros(n, dtype=np.float64)
+
+    if n == 0:
+        return (new_start, new_end)
 
     ct = 0
     new_start[ct] = starts[0]

--- a/pynapple/core/_jitted_functions.py
+++ b/pynapple/core/_jitted_functions.py
@@ -11,6 +11,9 @@ def jitrestrict(time_array, starts, ends):
     m = len(starts)
     ix = np.zeros(n, dtype=np.int64)
 
+    if n == 0 or m == 0:
+        return np.empty(0, dtype=np.int64)
+
     k = 0
     t = 0
     x = 0
@@ -52,11 +55,14 @@ def jitrestrict_with_count(time_array, starts, ends, dtype=np.int64):
     ix = np.zeros(n, dtype=np.int64)
     count = np.zeros(m, dtype=dtype)
 
+    if n == 0 or m == 0:
+        return np.empty(0, dtype=np.int64), np.zeros(m, dtype=dtype)
+
     k = 0
     t = 0
     x = 0
 
-    while ends[k] < time_array[t]:
+    while k < m and ends[k] < time_array[t]:
         k += 1
 
     while k < m:

--- a/tests/test_jitted.py
+++ b/tests/test_jitted.py
@@ -100,7 +100,9 @@ def test_jitrestrict_empty_epochs():
 def test_jitrestrict_with_count_empty_time_array():
     ep, ts, tsd, tsdframe = get_example_dataset()
     empty = np.array([], dtype=np.float64)
-    ix, count = nap.core._jitted_functions.jitrestrict_with_count(empty, ep.start, ep.end)
+    ix, count = nap.core._jitted_functions.jitrestrict_with_count(
+        empty, ep.start, ep.end
+    )
     assert len(ix) == 0
     assert len(count) == len(ep)
     np.testing.assert_array_equal(count, np.zeros(len(ep), dtype=np.int64))
@@ -109,7 +111,9 @@ def test_jitrestrict_with_count_empty_time_array():
 def test_jitrestrict_with_count_empty_epochs():
     ep, ts, tsd, tsdframe = get_example_dataset()
     empty = np.array([], dtype=np.float64)
-    ix, count = nap.core._jitted_functions.jitrestrict_with_count(tsd.index, empty, empty)
+    ix, count = nap.core._jitted_functions.jitrestrict_with_count(
+        tsd.index, empty, empty
+    )
     assert len(ix) == 0
     assert len(count) == 0
 

--- a/tests/test_jitted.py
+++ b/tests/test_jitted.py
@@ -555,10 +555,13 @@ def test_jitin_interval():
 
 # ── Edge-case tests ────────────────────────────────────────────────────────────
 
+
 def test_jitrestrict_empty_time_array():
     starts = np.array([0.0, 5.0])
     ends = np.array([2.0, 8.0])
-    ix = nap.core._jitted_functions.jitrestrict(np.array([], dtype=np.float64), starts, ends)
+    ix = nap.core._jitted_functions.jitrestrict(
+        np.array([], dtype=np.float64), starts, ends
+    )
     assert len(ix) == 0
 
 
@@ -660,7 +663,7 @@ def test_jitvaluefrom_single_target_mode_before():
         time_array, time_target, count, count_target, starts, 0
     )
     assert np.isnan(idx[0])  # target 1.5 is after timestamp 1.0 → no before-target
-    assert idx[1] == 0.0     # target 1.5 is before timestamp 2.0 → target index 0
+    assert idx[1] == 0.0  # target 1.5 is before timestamp 2.0 → target index 0
 
 
 def test_jitvaluefrom_single_target_mode_after():
@@ -673,5 +676,5 @@ def test_jitvaluefrom_single_target_mode_after():
     idx = nap.core._jitted_functions.jitvaluefrom(
         time_array, time_target, count, count_target, starts, 2
     )
-    assert idx[0] == 0.0    # target 1.5 is after timestamp 1.0 → target index 0
-    assert np.isnan(idx[1]) # target 1.5 is before timestamp 2.0 → no after-target
+    assert idx[0] == 0.0  # target 1.5 is after timestamp 1.0 → target index 0
+    assert np.isnan(idx[1])  # target 1.5 is before timestamp 2.0 → no after-target

--- a/tests/test_jitted.py
+++ b/tests/test_jitted.py
@@ -83,6 +83,37 @@ def test_jitrestrict():
         np.testing.assert_array_almost_equal(tsd2.index.values, tsd3.index.values)
 
 
+def test_jitrestrict_empty_time_array():
+    ep, ts, tsd, tsdframe = get_example_dataset()
+    empty = np.array([], dtype=np.float64)
+    ix = nap.core._jitted_functions.jitrestrict(empty, ep.start, ep.end)
+    assert len(ix) == 0
+
+
+def test_jitrestrict_empty_epochs():
+    ep, ts, tsd, tsdframe = get_example_dataset()
+    empty = np.array([], dtype=np.float64)
+    ix = nap.core._jitted_functions.jitrestrict(tsd.index, empty, empty)
+    assert len(ix) == 0
+
+
+def test_jitrestrict_with_count_empty_time_array():
+    ep, ts, tsd, tsdframe = get_example_dataset()
+    empty = np.array([], dtype=np.float64)
+    ix, count = nap.core._jitted_functions.jitrestrict_with_count(empty, ep.start, ep.end)
+    assert len(ix) == 0
+    assert len(count) == len(ep)
+    np.testing.assert_array_equal(count, np.zeros(len(ep), dtype=np.int64))
+
+
+def test_jitrestrict_with_count_empty_epochs():
+    ep, ts, tsd, tsdframe = get_example_dataset()
+    empty = np.array([], dtype=np.float64)
+    ix, count = nap.core._jitted_functions.jitrestrict_with_count(tsd.index, empty, empty)
+    assert len(ix) == 0
+    assert len(count) == 0
+
+
 def test_jitrestrict_with_count():
     for i in range(100):
         ep, ts, tsd, tsdframe = get_example_dataset()

--- a/tests/test_jitted.py
+++ b/tests/test_jitted.py
@@ -516,3 +516,127 @@ def test_jitin_interval():
         inep2[np.isnan(inep2)] = -1
 
         np.testing.assert_array_equal(inep, inep2)
+
+
+# ── Edge-case tests ────────────────────────────────────────────────────────────
+
+def test_jitrestrict_empty_time_array():
+    starts = np.array([0.0, 5.0])
+    ends = np.array([2.0, 8.0])
+    ix = nap.core._jitted_functions.jitrestrict(np.array([], dtype=np.float64), starts, ends)
+    assert len(ix) == 0
+
+
+def test_jitrestrict_empty_epochs():
+    time_array = np.array([1.0, 2.0, 3.0])
+    ix = nap.core._jitted_functions.jitrestrict(
+        time_array, np.array([], dtype=np.float64), np.array([], dtype=np.float64)
+    )
+    assert len(ix) == 0
+
+
+def test_jitrestrict_with_count_empty_time_array():
+    starts = np.array([0.0, 5.0])
+    ends = np.array([2.0, 8.0])
+    ix, count = nap.core._jitted_functions.jitrestrict_with_count(
+        np.array([], dtype=np.float64), starts, ends
+    )
+    assert len(ix) == 0
+    np.testing.assert_array_equal(count, np.zeros(2, dtype=np.int64))
+
+
+def test_jitrestrict_with_count_empty_epochs():
+    time_array = np.array([1.0, 2.0, 3.0])
+    ix, count = nap.core._jitted_functions.jitrestrict_with_count(
+        time_array, np.array([], dtype=np.float64), np.array([], dtype=np.float64)
+    )
+    assert len(ix) == 0
+    assert len(count) == 0
+
+
+def test_jitin_interval_empty_time_array():
+    starts = np.array([0.0])
+    ends = np.array([10.0])
+    data = nap.core._jitted_functions.jitin_interval(
+        np.array([], dtype=np.float64), starts, ends
+    )
+    assert len(data) == 0
+
+
+def test_jitin_interval_empty_epochs():
+    time_array = np.array([1.0, 2.0, 3.0])
+    data = nap.core._jitted_functions.jitin_interval(
+        time_array, np.array([], dtype=np.float64), np.array([], dtype=np.float64)
+    )
+    assert len(data) == 3
+    assert np.all(np.isnan(data))
+
+
+def test_jitremove_nan_empty():
+    starts, ends = nap.core._jitted_functions.jitremove_nan(
+        np.array([], dtype=np.float64), np.array([], dtype=np.bool_)
+    )
+    assert len(starts) == 0
+    assert len(ends) == 0
+
+
+def test_jitthreshold_single_element_above():
+    time_array = np.array([5.0])
+    data_array = np.array([1.0])
+    starts = np.array([0.0])
+    ends = np.array([10.0])
+    t, d, s, e = nap.core._jitted_functions.jitthreshold(
+        time_array, data_array, starts, ends, 0.5
+    )
+    assert len(t) == 1
+    assert len(s) == 1
+    assert len(e) == 1
+
+
+def test_jitthreshold_single_element_below():
+    time_array = np.array([5.0])
+    data_array = np.array([0.0])
+    starts = np.array([0.0])
+    ends = np.array([10.0])
+    t, d, s, e = nap.core._jitted_functions.jitthreshold(
+        time_array, data_array, starts, ends, 0.5
+    )
+    assert len(t) == 0
+    assert len(s) == 0
+    assert len(e) == 0
+
+
+def test_jitunion_isets_empty():
+    s, e = nap.core._jitted_functions.jitunion_isets(
+        np.array([], dtype=np.float64), np.array([], dtype=np.float64)
+    )
+    assert len(s) == 0
+    assert len(e) == 0
+
+
+def test_jitvaluefrom_single_target_mode_before():
+    # count_target[k]==1 triggers undefined nan_cond when mode=0
+    time_array = np.array([1.0, 2.0])
+    time_target = np.array([1.5])
+    count = np.array([2], dtype=np.int64)
+    count_target = np.array([1], dtype=np.int64)
+    starts = np.array([0.0])
+    idx = nap.core._jitted_functions.jitvaluefrom(
+        time_array, time_target, count, count_target, starts, 0
+    )
+    assert np.isnan(idx[0])  # target 1.5 is after timestamp 1.0 → no before-target
+    assert idx[1] == 0.0     # target 1.5 is before timestamp 2.0 → target index 0
+
+
+def test_jitvaluefrom_single_target_mode_after():
+    # count_target[k]==1, mode=2 (already handled, regression guard)
+    time_array = np.array([1.0, 2.0])
+    time_target = np.array([1.5])
+    count = np.array([2], dtype=np.int64)
+    count_target = np.array([1], dtype=np.int64)
+    starts = np.array([0.0])
+    idx = nap.core._jitted_functions.jitvaluefrom(
+        time_array, time_target, count, count_target, starts, 2
+    )
+    assert idx[0] == 0.0    # target 1.5 is after timestamp 1.0 → target index 0
+    assert np.isnan(idx[1]) # target 1.5 is before timestamp 2.0 → no after-target


### PR DESCRIPTION
This pull request addresses several edge-case bugs and improves robustness in the jitted core functions, especially when handling empty input arrays or single-element cases. It also adds comprehensive tests to cover these cases and documents the fixes in the release notes.

**Bug fixes in jitted core functions:**

* Fixed out-of-bounds memory access and crashes in `jitrestrict`, `jitrestrict_with_count`, `jitin_interval`, `jitremove_nan`, `jitthreshold`, and `jitunion_isets` when called with empty time arrays or empty epoch sets. These previously led to random crashes or segfaults with Numba JIT enabled, or `IndexError` with JIT disabled. Now, these functions return appropriate empty outputs. [[1]](diffhunk://#diff-22c5bdaa8cce13e29fc28d02ae3c31ffdecb11b77973cc4e6e6769683e6ab1ffR14-R16) [[2]](diffhunk://#diff-22c5bdaa8cce13e29fc28d02ae3c31ffdecb11b77973cc4e6e6769683e6ab1ffR58-R65) [[3]](diffhunk://#diff-22c5bdaa8cce13e29fc28d02ae3c31ffdecb11b77973cc4e6e6769683e6ab1ffR254-R260) [[4]](diffhunk://#diff-22c5bdaa8cce13e29fc28d02ae3c31ffdecb11b77973cc4e6e6769683e6ab1ffR297-R299) [[5]](diffhunk://#diff-22c5bdaa8cce13e29fc28d02ae3c31ffdecb11b77973cc4e6e6769683e6ab1ffL327-R358) [[6]](diffhunk://#diff-22c5bdaa8cce13e29fc28d02ae3c31ffdecb11b77973cc4e6e6769683e6ab1ffR730-R732)
* Added missing bounds checks to prevent out-of-bounds reads in `jitrestrict_with_count` and `jitin_interval` when all epoch ends are before the first timestamp. [[1]](diffhunk://#diff-22c5bdaa8cce13e29fc28d02ae3c31ffdecb11b77973cc4e6e6769683e6ab1ffR58-R65) [[2]](diffhunk://#diff-22c5bdaa8cce13e29fc28d02ae3c31ffdecb11b77973cc4e6e6769683e6ab1ffR254-R260)
* Fixed `jitthreshold` to correctly handle single-element input arrays, preventing out-of-bounds access.
* Fixed undefined `nan_cond` variable in `jitvaluefrom` for epochs containing exactly one target timestamp and mode is `before` or `closest`, ensuring correct `NaN` results instead of silent errors.
* Fixed `compute_perievent` (via `jitvaluefrom`) crash on `TsGroup` inputs when any event has no spikes within the requested window.

**Testing improvements:**

* Added extensive edge-case tests for all affected jitted functions, covering empty arrays, empty epochs, single-element cases, and the specific bugs fixed above. [[1]](diffhunk://#diff-95eed2f05cf1c49a12a2d97258600d841e78abac341ae24cff59fb4f779712e1R86-R120) [[2]](diffhunk://#diff-95eed2f05cf1c49a12a2d97258600d841e78abac341ae24cff59fb4f779712e1R554-R680)

**Documentation:**

* Updated the release notes in `doc/releases.md` to summarize all the bug fixes and improvements included in this patch.