### PR TITLE
utc time

### DIFF
--- a/pynapple/core/time_index.py
+++ b/pynapple/core/time_index.py
@@ -44,15 +44,14 @@ class TsIndex(np.ndarray):
             Description
         """
         if units == "s":
-            t = np.around(t, nap_config.time_index_precision)
+            return t
+        #     t = np.around(t, nap_config.time_index_precision)
         elif units == "ms":
-            t = np.around(t / 1.0e3, nap_config.time_index_precision)
+            return np.around(t / 1.0e3, nap_config.time_index_precision)
         elif units == "us":
-            t = np.around(t / 1.0e6, nap_config.time_index_precision)
+            return np.around(t / 1.0e6, nap_config.time_index_precision)
         else:
             raise ValueError("unrecognized time units type")
-
-        return t
 
     @staticmethod
     def return_timestamps(t, units="s"):
@@ -77,15 +76,14 @@ class TsIndex(np.ndarray):
             IF units is not in ['s', 'ms', 'us']
         """
         if units == "s":
-            t = np.around(t, nap_config.time_index_precision)
+            return t
+        #     t = np.around(t)#, nap_config.time_index_precision)
         elif units == "ms":
-            t = np.around(t * 1.0e3, nap_config.time_index_precision)
+            return np.around(t * 1.0e3, nap_config.time_index_precision)
         elif units == "us":
-            t = np.around(t * 1.0e6, nap_config.time_index_precision)
+            return np.around(t * 1.0e6, nap_config.time_index_precision)
         else:
             raise ValueError("unrecognized time units type")
-
-        return t
 
     @staticmethod
     def sort_timestamps(t, give_warning=True):


### PR DESCRIPTION
This pull request refactors the `format_timestamps` and `return_timestamps` methods in `pynapple/core/time_index.py` to simplify their logic and improve clarity. The main change is to return the timestamp arrays directly for seconds without rounding, and to return immediately in each conditional branch, removing redundant code.

**Refactoring and simplification:**

* [`format_timestamps`](diffhunk://#diff-ffafe6fce6b439f485d7f188673127fe3b3f46fec69c3d115e6e7417ca7367bcL47-L56): Now returns the input array directly when units are seconds (`"s"`), and only applies rounding for milliseconds (`"ms"`) and microseconds (`"us"`). The function now returns immediately in each branch, eliminating unnecessary variable assignments and the final return statement.
* [`return_timestamps`](diffhunk://#diff-ffafe6fce6b439f485d7f188673127fe3b3f46fec69c3d115e6e7417ca7367bcL80-L89): Similarly, now returns the input array directly for seconds, and immediately returns the appropriately converted and rounded arrays for milliseconds and microseconds. This also removes redundant code and improves readability.