### PR TITLE
hotfix

### DIFF
--- a/pynapple/io/interface_neurosuite.py
+++ b/pynapple/io/interface_neurosuite.py
@@ -295,8 +295,8 @@ class NeuroSuiteIO:
             for ch in channels:
                 ch_id = ch["id"]
                 self.channel_order[count] = ch_id
-                self.skip[count] = ch["skip"]
-                self.groups[ch["id"]] = group_idx
+                self.skip[ch_id] = ch["skip"]
+                self.groups[ch_id] = group_idx
                 count += 1
         self.binary_metadata = {
             "anatomy": np.argsort(self.channel_order),  # Different for pynaviz


### PR DESCRIPTION
This pull request makes a small but important fix to the initialization logic in `pynapple/io/interface_neurosuite.py`. The update ensures that the `skip` and `groups` dictionaries are correctly keyed by channel ID, improving data consistency and preventing potential indexing errors.

- Bug fix:
  * Updated assignment to `self.skip` and `self.groups` to use `ch_id` as the key instead of the loop counter `count`, ensuring correct mapping of channel metadata.