### PR TITLE
Security: Unsafe np.load with allow_pickle=True in NPZFile

### DIFF
--- a/pynapple/io/interface_npz.py
+++ b/pynapple/io/interface_npz.py
@@ -62,7 +62,7 @@ class NPZFile(object):
         path = Path(path)
         self.path = path
         self.name = path.name
-        self.file = np.load(self.path, allow_pickle=True)
+        self.file = np.load(self.path, allow_pickle=False)
         type_ = ""
 
         # First check if type is explicitely defined in the file:


### PR DESCRIPTION
## Summary

Security: Unsafe np.load with allow_pickle=True in NPZFile

## Problem

**Severity**: `High` | **File**: `pynapple/io/interface_npz.py:L78`

The NPZFile class uses np.load with allow_pickle=True, which can execute arbitrary code when loading maliciously crafted NPZ files. This is a known security vulnerability in NumPy's loading mechanism that allows for remote code execution through pickled objects.

## Solution

Consider using allow_pickle=False if the use case permits, or implement strict validation of file contents before loading. If pickle support is required, document the security implications and consider adding warnings or sandboxing.

## Changes

- `pynapple/io/interface_npz.py` (modified)