### PR TITLE
First comit for movement integration

### DIFF
--- a/movement_example.py
+++ b/movement_example.py
@@ -1,0 +1,53 @@
+"""
+Movement → Pynapple minimal example
+Based on: https://movement.neuroinformatics.dev/latest/examples/scale.html
+"""
+
+import warnings
+from movement import sample_data
+from movement.filtering import filter_by_confidence, interpolate_over_time, median_filter
+from movement.transforms import scale
+import pynapple as nap
+
+warnings.filterwarnings("ignore")
+
+# ---------------------------------------------------------------------------
+# Load and pre-process
+# ---------------------------------------------------------------------------
+
+ds = sample_data.fetch_dataset("DLC_single-mouse_DBTravelator_2D.predictions.h5")
+
+kp_dim  = "keypoint"   if "keypoint"   in ds.coords else "keypoints"
+ind_dim = "individual" if "individual" in ds.coords else "individuals"
+
+landmark_keypoints = [
+    "Door", "StartPlatL", "StartPlatR", "StepL", "StepR", "TransitionL", "TransitionR",
+]
+
+ds_mouse = ds.sel(
+    {
+        kp_dim:  ~ds[kp_dim].isin(landmark_keypoints),
+        ind_dim: ds[ind_dim].values[0],
+    }
+)
+
+ds_mouse["position"] = filter_by_confidence(ds_mouse.position, ds_mouse.confidence, threshold=0.9)
+ds_mouse["position"] = interpolate_over_time(ds_mouse.position, max_gap=40)
+ds_mouse["position"] = median_filter(ds_mouse.position, window=6, min_periods=2)
+
+# Scale pixels → cm (1 cm grid ≈ 29 px) and flip y-axis
+ds_mouse["position"] = scale(ds_mouse["position"], factor=1.0 / 29.0, space_unit="cm")
+y = ds_mouse["position"].sel(space="y")
+ds_mouse["position"].loc[dict(space="y")] = y.max() - y
+
+# ---------------------------------------------------------------------------
+# Convert to pynapple
+# ---------------------------------------------------------------------------
+
+data = nap.from_movement(ds_mouse)
+print(data)
+
+position   = data["position"]    # TsdFrame — columns: Nose_x, Nose_y, EarL_x, ...
+confidence = data["confidence"]  # TsdFrame — columns: Nose, EarL, ...
+
+print(position)

--- a/pynapple/io/__init__.py
+++ b/pynapple/io/__init__.py
@@ -1,4 +1,5 @@
 from .folder import Folder
+from .movement import from_movement
 from .interface_neo import EphysReader, NeoSignalInterface
 from .interface_npz import NPZFile
 from .interface_nwb import NWBFile

--- a/pynapple/io/movement.py
+++ b/pynapple/io/movement.py
@@ -1,0 +1,314 @@
+"""
+Pynapple interface for the movement package.
+Converts movement xarray.Dataset objects to pynapple time series.
+"""
+
+from collections import UserDict
+
+import numpy as np
+from tabulate import tabulate
+
+from .. import core as nap
+
+
+def _check_xarray():
+    try:
+        import xarray  # noqa: F401
+    except ImportError:
+        raise ImportError(
+            "The 'xarray' package is required to use from_movement. "
+            "Install it with: pip install xarray"
+        )
+
+
+def _dim(ds, *candidates):
+    """Return the first candidate that exists as a coordinate in ds."""
+    for name in candidates:
+        if name in ds.coords:
+            return name
+    raise KeyError(
+        f"None of {candidates} found in dataset coordinates: {list(ds.coords)}"
+    )
+
+
+def _ind_values(ds):
+    """Return the list of individual names, handling scalar (dropped-dim) case."""
+    ind_dim = _dim(ds, "individual", "individuals")
+    val = ds.coords[ind_dim].values.tolist()
+    # After ds.sel(individuals="name") the coord becomes a 0-d scalar string
+    if isinstance(val, str):
+        return [val]
+    return val
+
+
+def _validate_movement_dataset(ds):
+    """Validate that ds is a supported movement xarray.Dataset."""
+    _check_xarray()
+    import xarray as xr
+
+    if not isinstance(ds, xr.Dataset):
+        raise TypeError(f"Expected an xarray.Dataset, got {type(ds).__name__}.")
+
+    ds_type = ds.attrs.get("ds_type")
+    if ds_type not in ("poses", "bboxes"):
+        raise ValueError(
+            f"Dataset 'ds_type' attribute must be 'poses' or 'bboxes', got {ds_type!r}. "
+            "Make sure this dataset was created by the movement package."
+        )
+
+    time_unit = ds.attrs.get("time_unit", "seconds")
+    if time_unit != "seconds":
+        raise ValueError(
+            f"Dataset time_unit is {time_unit!r}. Pynapple requires time in seconds. "
+            "Reload the movement dataset with fps provided so that time is in seconds."
+        )
+
+    required = {
+        "poses": ["position", "confidence"],
+        "bboxes": ["position", "shape", "confidence"],
+    }
+    for var in required[ds_type]:
+        if var not in ds:
+            raise ValueError(
+                f"Expected variable '{var}' not found in the dataset."
+            )
+
+    # Ensure individual/individuals and (for poses) keypoint/keypoints are present
+    _dim(ds, "individual", "individuals")
+    if ds_type == "poses":
+        _dim(ds, "keypoint", "keypoints")
+
+
+def _col_preview(cols, n):
+    """Short column preview: 'a, b, c, ...  (n)'."""
+    preview = ", ".join(str(c) for c in cols[:3])
+    if n > 3:
+        preview += ", ..."
+    return f"{preview}  ({n})"
+
+
+def _build_view_rows(ds, individuals):
+    """Build tabulate rows from xarray metadata — no pynapple objects created."""
+    ds_type = ds.attrs.get("ds_type")
+    n_t = len(ds.coords["time"])
+    rows = []
+
+    for ind in individuals:
+        if ds_type == "poses":
+            kp_dim = _dim(ds, "keypoint", "keypoints")
+            keypoints = ds.coords[kp_dim].values.tolist()
+            spaces = ds.coords["space"].values.tolist()
+            pos_cols = [f"{kp}_{sp}" for kp in keypoints for sp in spaces]
+            rows.append([ind, "position", "TsdFrame", _col_preview(pos_cols, len(pos_cols))])
+            rows.append([ind, "confidence", "TsdFrame", _col_preview(keypoints, len(keypoints))])
+        else:  # bboxes
+            rows.append([ind, "position", "TsdFrame", "x, y  (2)"])
+            rows.append([ind, "shape", "TsdFrame", "width, height  (2)"])
+            rows.append([ind, "confidence", "Tsd", f"({n_t},)"])
+
+    return rows
+
+
+def _sel_individual(da, ind_dim, ind_name):
+    """Select one individual from a DataArray, handling scalar (dropped-dim) case."""
+    if ind_dim in da.dims:
+        return da.sel({ind_dim: ind_name})
+    # Dimension was already dropped by an upstream .sel() call — data is already
+    # for this individual, just return as-is
+    return da
+
+
+def _poses_individual_to_pynapple(ds, ind_name):
+    """Convert a single individual's poses data to pynapple objects."""
+    t = ds.coords["time"].values
+    kp_dim = _dim(ds, "keypoint", "keypoints")
+    ind_dim = _dim(ds, "individual", "individuals")
+    keypoints = ds.coords[kp_dim].values.tolist()
+    spaces = ds.coords["space"].values.tolist()
+
+    # position: (time, space, keypoint) — select individual if dimension still present
+    pos = _sel_individual(ds["position"], ind_dim, ind_name).values
+    n_t, n_space, n_kp = pos.shape
+
+    # Flatten to (time, n_kp * n_space) with columns: nose_x, nose_y, ear_x, ear_y, ...
+    cols = [f"{kp}_{sp}" for kp in keypoints for sp in spaces]
+    d_pos = pos.transpose(0, 2, 1).reshape(n_t, n_kp * n_space)
+    position = nap.TsdFrame(t=t, d=d_pos, columns=cols)
+
+    # confidence: (time, keypoint)
+    conf = _sel_individual(ds["confidence"], ind_dim, ind_name).values
+    confidence = nap.TsdFrame(t=t, d=conf, columns=keypoints)
+
+    return {"position": position, "confidence": confidence}
+
+
+def _bboxes_individual_to_pynapple(ds, ind_name):
+    """Convert a single individual's bboxes data to pynapple objects."""
+    t = ds.coords["time"].values
+    ind_dim = _dim(ds, "individual", "individuals")
+
+    # position: (time, space)
+    pos = _sel_individual(ds["position"], ind_dim, ind_name).values
+    position = nap.TsdFrame(t=t, d=pos, columns=["x", "y"])
+
+    # shape: (time, space)
+    shp = _sel_individual(ds["shape"], ind_dim, ind_name).values
+    shape = nap.TsdFrame(t=t, d=shp, columns=["width", "height"])
+
+    # confidence: (time,)
+    conf = _sel_individual(ds["confidence"], ind_dim, ind_name).values.ravel()
+    confidence = nap.Tsd(t=t, d=conf)
+
+    return {"position": position, "shape": shape, "confidence": confidence}
+
+
+def _individual_to_pynapple(ds, ind_name):
+    ds_type = ds.attrs.get("ds_type")
+    if ds_type == "poses":
+        return _poses_individual_to_pynapple(ds, ind_name)
+    return _bboxes_individual_to_pynapple(ds, ind_name)
+
+
+def _variable_keys(ds):
+    ds_type = ds.attrs.get("ds_type")
+    if ds_type == "poses":
+        return ["position", "confidence"]
+    return ["position", "shape", "confidence"]
+
+
+class MovementDataset(UserDict):
+    """
+    Dict-like container returned by from_movement().
+
+    Prints a preview table on repr (same style as NWBFile).
+    Pynapple objects are built lazily on first access.
+
+    For a single individual (or when individual= is passed to from_movement),
+    keys are variable names: 'position', 'confidence' (and 'shape' for bboxes).
+    For multiple individuals, keys are individual names — each resolving to
+    a per-individual MovementDataset.
+
+    Examples
+    --------
+    >>> import pynapple as nap
+    >>> data = nap.from_movement(ds)
+    >>> data
+    test.h5  (poses | 100 frames | 10.0 fps)
+    ╭──────────────┬────────────────┬──────────┬──────────────────────────────────────╮
+    │ Individual   │ Variable       │ Type     │ Columns / Shape                      │
+    ├──────────────┼────────────────┼──────────┼──────────────────────────────────────┤
+    │ mouse1       │ position       │ TsdFrame │ nose_x, nose_y, left_ear_x, ...  (6) │
+    │ mouse1       │ confidence     │ TsdFrame │ nose, left_ear, right_ear  (3)       │
+    ╰──────────────┴────────────────┴──────────┴──────────────────────────────────────╯
+    >>> data['position']
+    Time (s)    nose_x    nose_y    ...
+    """
+
+    def __init__(self, ds, individuals, name=""):
+        self._ds = ds
+        self._individuals = list(individuals)
+        self._name = name
+        self._single = len(self._individuals) == 1
+        self._view = _build_view_rows(ds, self._individuals)
+
+        # Pre-populate data dict with None sentinels so keys(), __contains__, __iter__ work
+        keys = _variable_keys(ds) if self._single else self._individuals
+        UserDict.__init__(self, {k: None for k in keys})
+
+    def __repr__(self):
+        ds_type = self._ds.attrs.get("ds_type", "?")
+        n_frames = len(self._ds.coords["time"])
+        fps = self._ds.attrs.get("fps", "?")
+        title = f"{self._name}  ({ds_type} | {n_frames} frames | {fps} fps)\n"
+        headers = ["Individual", "Variable", "Type", "Columns / Shape"]
+        return title + tabulate(self._view, headers=headers, tablefmt="mixed_outline")
+
+    def __getitem__(self, key):
+        if key not in self.data:
+            raise KeyError(key)
+        if self.data[key] is None:
+            self._load(key)
+        return self.data[key]
+
+    def _load(self, key):
+        if self._single:
+            # Load all variables for this individual at once and cache them
+            ind = self._individuals[0]
+            objects = _individual_to_pynapple(self._ds, ind)
+            for k, v in objects.items():
+                if k in self.data:
+                    self.data[k] = v
+        else:
+            # Multi-individual: build a sub-MovementDataset for this individual
+            self.data[key] = MovementDataset(self._ds, [key], name=key)
+
+
+def from_movement(ds, individual=None):
+    """
+    Convert a movement xarray.Dataset to a MovementDataset.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        A movement poses or bboxes dataset (ds.attrs['ds_type'] must be 'poses'
+        or 'bboxes', and ds.attrs['time_unit'] must be 'seconds').
+    individual : str, optional
+        If provided, expose only this individual at the top level. The returned
+        MovementDataset will have variable names as keys ('position', 'confidence',
+        etc.) rather than individual names.
+
+    Returns
+    -------
+    MovementDataset
+        Dict-like object. Prints a preview table on repr.
+
+        - Single individual (or individual= given): keys are 'position',
+          'confidence' (and 'shape' for bboxes datasets).
+        - Multiple individuals: keys are individual names, each resolving to
+          a per-individual MovementDataset with variable-name keys.
+
+    Raises
+    ------
+    TypeError
+        If ds is not an xarray.Dataset.
+    ValueError
+        If ds_type is not 'poses' or 'bboxes', if time_unit is not 'seconds',
+        or if required variables are missing.
+    ImportError
+        If xarray is not installed.
+
+    Examples
+    --------
+    Single individual:
+
+    >>> import pynapple as nap
+    >>> data = nap.from_movement(ds)
+    >>> position = data['position']   # TsdFrame with columns nose_x, nose_y, ...
+    >>> confidence = data['confidence']
+
+    Multiple individuals:
+
+    >>> data = nap.from_movement(ds_multi)
+    >>> mouse1_pos = data['mouse1']['position']
+
+    Select one individual from a multi-individual dataset:
+
+    >>> data = nap.from_movement(ds_multi, individual='mouse1')
+    >>> position = data['position']
+    """
+    _validate_movement_dataset(ds)
+
+    individuals = _ind_values(ds)
+    name = ds.attrs.get("source_file", "movement dataset")
+    if name:
+        name = str(name).split("/")[-1]  # basename only
+
+    if individual is not None:
+        if individual not in individuals:
+            raise ValueError(
+                f"Individual {individual!r} not found. "
+                f"Available individuals: {individuals}"
+            )
+        individuals = [individual]
+
+    return MovementDataset(ds, individuals, name=name)

--- a/tests/test_movement.py
+++ b/tests/test_movement.py
@@ -1,0 +1,316 @@
+"""Tests for pynapple.io.movement (from_movement / MovementDataset)."""
+
+import numpy as np
+import pytest
+
+xr = pytest.importorskip("xarray")
+
+import pynapple as nap
+from pynapple.io.movement import MovementDataset, from_movement
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: synthetic movement-style xarray.Dataset objects
+# ---------------------------------------------------------------------------
+
+
+def _make_poses_ds(n_individuals=1, n_keypoints=3, n_frames=100, fps=10.0):
+    n_sp = 2
+    ind_names = [f"mouse{i+1}" for i in range(n_individuals)]
+    kp_names = ["nose", "left_ear", "right_ear"][:n_keypoints]
+    t = np.arange(n_frames) / fps
+
+    return xr.Dataset(
+        {
+            "position": xr.DataArray(
+                np.random.rand(n_frames, n_sp, n_keypoints, n_individuals),
+                dims=["time", "space", "keypoint", "individual"],
+            ),
+            "confidence": xr.DataArray(
+                np.random.rand(n_frames, n_keypoints, n_individuals),
+                dims=["time", "keypoint", "individual"],
+            ),
+        },
+        coords={
+            "time": t,
+            "space": ["x", "y"],
+            "keypoint": kp_names,
+            "individual": ind_names,
+        },
+        attrs={
+            "ds_type": "poses",
+            "fps": fps,
+            "time_unit": "seconds",
+            "source_file": "test.h5",
+        },
+    )
+
+
+def _make_bboxes_ds(n_individuals=1, n_frames=50, fps=25.0):
+    n_sp = 2
+    ind_names = [f"id_{i}" for i in range(n_individuals)]
+    t = np.arange(n_frames) / fps
+
+    return xr.Dataset(
+        {
+            "position": xr.DataArray(
+                np.random.rand(n_frames, n_sp, n_individuals),
+                dims=["time", "space", "individual"],
+            ),
+            "shape": xr.DataArray(
+                np.random.rand(n_frames, n_sp, n_individuals),
+                dims=["time", "space", "individual"],
+            ),
+            "confidence": xr.DataArray(
+                np.random.rand(n_frames, n_individuals),
+                dims=["time", "individual"],
+            ),
+        },
+        coords={
+            "time": t,
+            "space": ["x", "y"],
+            "individual": ind_names,
+        },
+        attrs={
+            "ds_type": "bboxes",
+            "fps": fps,
+            "time_unit": "seconds",
+            "source_file": "test_bbox.h5",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_wrong_type_raises(self):
+        with pytest.raises(TypeError, match="xarray.Dataset"):
+            from_movement({"not": "a dataset"})
+
+    def test_missing_ds_type_raises(self):
+        ds = _make_poses_ds()
+        del ds.attrs["ds_type"]
+        with pytest.raises(ValueError, match="ds_type"):
+            from_movement(ds)
+
+    def test_invalid_ds_type_raises(self):
+        ds = _make_poses_ds()
+        ds.attrs["ds_type"] = "tracks"
+        with pytest.raises(ValueError, match="ds_type"):
+            from_movement(ds)
+
+    def test_wrong_time_unit_raises(self):
+        ds = _make_poses_ds()
+        ds.attrs["time_unit"] = "frames"
+        with pytest.raises(ValueError, match="time_unit"):
+            from_movement(ds)
+
+    def test_missing_variable_raises(self):
+        ds = _make_poses_ds()
+        ds = ds.drop_vars("confidence")
+        with pytest.raises(ValueError, match="confidence"):
+            from_movement(ds)
+
+    def test_invalid_individual_raises(self):
+        ds = _make_poses_ds(n_individuals=2)
+        with pytest.raises(ValueError, match="'ghost'"):
+            from_movement(ds, individual="ghost")
+
+
+# ---------------------------------------------------------------------------
+# Poses — single individual
+# ---------------------------------------------------------------------------
+
+
+class TestPosesSingleIndividual:
+    @pytest.fixture
+    def data(self):
+        return from_movement(_make_poses_ds(n_individuals=1, n_keypoints=3))
+
+    def test_returns_movement_dataset(self, data):
+        assert isinstance(data, MovementDataset)
+
+    def test_keys(self, data):
+        assert set(data.keys()) == {"position", "confidence"}
+
+    def test_position_type_and_shape(self, data):
+        pos = data["position"]
+        assert isinstance(pos, nap.TsdFrame)
+        assert pos.shape == (100, 6)  # n_frames x (n_kp * n_space)
+
+    def test_position_columns(self, data):
+        expected = ["nose_x", "nose_y", "left_ear_x", "left_ear_y", "right_ear_x", "right_ear_y"]
+        assert list(data["position"].columns) == expected
+
+    def test_confidence_type_and_shape(self, data):
+        conf = data["confidence"]
+        assert isinstance(conf, nap.TsdFrame)
+        assert conf.shape == (100, 3)
+
+    def test_confidence_columns(self, data):
+        assert list(data["confidence"].columns) == ["nose", "left_ear", "right_ear"]
+
+    def test_time_index(self, data):
+        expected_t = np.arange(100) / 10.0
+        np.testing.assert_allclose(data["position"].index.values, expected_t)
+
+    def test_repr_contains_ds_type(self, data):
+        assert "poses" in repr(data)
+
+    def test_repr_contains_filename(self, data):
+        assert "test.h5" in repr(data)
+
+    def test_lazy_loading(self):
+        ds = _make_poses_ds()
+        data = from_movement(ds)
+        # Before access, all values are None sentinels
+        assert all(v is None for v in data.data.values())
+        _ = data["position"]
+        # After access, all variables for the individual are populated
+        assert data.data["position"] is not None
+        assert data.data["confidence"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Poses — multiple individuals
+# ---------------------------------------------------------------------------
+
+
+class TestPosesMultipleIndividuals:
+    @pytest.fixture
+    def data(self):
+        return from_movement(_make_poses_ds(n_individuals=2, n_keypoints=3))
+
+    def test_keys_are_individual_names(self, data):
+        assert set(data.keys()) == {"mouse1", "mouse2"}
+
+    def test_subitem_is_movement_dataset(self, data):
+        assert isinstance(data["mouse1"], MovementDataset)
+
+    def test_subitem_keys(self, data):
+        assert set(data["mouse1"].keys()) == {"position", "confidence"}
+
+    def test_position_shape_per_individual(self, data):
+        pos = data["mouse1"]["position"]
+        assert isinstance(pos, nap.TsdFrame)
+        assert pos.shape == (100, 6)
+
+    def test_individuals_have_same_columns(self, data):
+        assert list(data["mouse1"]["position"].columns) == list(
+            data["mouse2"]["position"].columns
+        )
+
+    def test_repr_lists_all_individuals(self, data):
+        r = repr(data)
+        assert "mouse1" in r
+        assert "mouse2" in r
+
+
+# ---------------------------------------------------------------------------
+# Poses — individual= filter argument
+# ---------------------------------------------------------------------------
+
+
+class TestPosesIndividualFilter:
+    def test_returns_flat_dataset(self):
+        ds = _make_poses_ds(n_individuals=2)
+        data = from_movement(ds, individual="mouse1")
+        assert set(data.keys()) == {"position", "confidence"}
+
+    def test_position_values_match(self):
+        ds = _make_poses_ds(n_individuals=2)
+        data_filtered = from_movement(ds, individual="mouse1")
+        data_full = from_movement(ds)
+        np.testing.assert_allclose(
+            data_filtered["position"].values,
+            data_full["mouse1"]["position"].values,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bboxes — single individual
+# ---------------------------------------------------------------------------
+
+
+class TestBboxesSingleIndividual:
+    @pytest.fixture
+    def data(self):
+        return from_movement(_make_bboxes_ds(n_individuals=1))
+
+    def test_keys(self, data):
+        assert set(data.keys()) == {"position", "shape", "confidence"}
+
+    def test_position_type_and_columns(self, data):
+        pos = data["position"]
+        assert isinstance(pos, nap.TsdFrame)
+        assert list(pos.columns) == ["x", "y"]
+
+    def test_shape_type_and_columns(self, data):
+        shp = data["shape"]
+        assert isinstance(shp, nap.TsdFrame)
+        assert list(shp.columns) == ["width", "height"]
+
+    def test_confidence_is_tsd(self, data):
+        conf = data["confidence"]
+        assert isinstance(conf, nap.Tsd)
+        assert conf.shape == (50,)
+
+    def test_time_index(self, data):
+        expected_t = np.arange(50) / 25.0
+        np.testing.assert_allclose(data["position"].index.values, expected_t)
+
+
+# ---------------------------------------------------------------------------
+# Bboxes — multiple individuals
+# ---------------------------------------------------------------------------
+
+
+class TestBboxesMultipleIndividuals:
+    @pytest.fixture
+    def data(self):
+        return from_movement(_make_bboxes_ds(n_individuals=3))
+
+    def test_keys_are_individual_names(self, data):
+        assert set(data.keys()) == {"id_0", "id_1", "id_2"}
+
+    def test_subitem_keys(self, data):
+        assert set(data["id_0"].keys()) == {"position", "shape", "confidence"}
+
+    def test_confidence_is_tsd_per_individual(self, data):
+        assert isinstance(data["id_1"]["confidence"], nap.Tsd)
+
+
+# ---------------------------------------------------------------------------
+# Preview table
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewTable:
+    def test_view_rows_poses(self):
+        data = from_movement(_make_poses_ds(n_individuals=1, n_keypoints=3))
+        # 2 rows: position, confidence
+        assert len(data._view) == 2
+        assert data._view[0][1] == "position"
+        assert data._view[1][1] == "confidence"
+
+    def test_view_rows_bboxes(self):
+        data = from_movement(_make_bboxes_ds(n_individuals=1))
+        # 3 rows: position, shape, confidence
+        assert len(data._view) == 3
+        assert {r[1] for r in data._view} == {"position", "shape", "confidence"}
+
+    def test_view_rows_multi_individual(self):
+        data = from_movement(_make_poses_ds(n_individuals=2, n_keypoints=3))
+        # 4 rows: 2 individuals × 2 variables
+        assert len(data._view) == 4
+
+    def test_repr_is_string(self):
+        data = from_movement(_make_poses_ds())
+        assert isinstance(repr(data), str)
+
+    def test_repr_contains_fps(self):
+        data = from_movement(_make_poses_ds(fps=30.0))
+        assert "30.0" in repr(data)


### PR DESCRIPTION
    >>> import pynapple as nap
    >>> data = nap.from_movement(ds)
    >>> data
    test.h5  (poses | 100 frames | 10.0 fps)
    ╭──────────────┬────────────────┬──────────┬──────────────────────────────────────╮
    │ Individual   │ Variable       │ Type     │ Columns / Shape                      │
    ├──────────────┼────────────────┼──────────┼──────────────────────────────────────┤
    │ mouse1       │ position       │ TsdFrame │ nose_x, nose_y, left_ear_x, ...  (6) │
    │ mouse1       │ confidence     │ TsdFrame │ nose, left_ear, right_ear  (3)       │
    ╰──────────────┴────────────────┴──────────┴──────────────────────────────────────╯
    >>> data['position']
    Time (s)    nose_x    nose_y    ...

This pull request adds a new interface for importing and working with datasets from the `movement` package in Pynapple. It introduces a robust conversion utility (`from_movement`) and a dict-like container (`MovementDataset`) for handling pose and bounding box data, with support for multiple individuals and lazy loading of time series. Additionally, comprehensive tests and a minimal user example are included.

**Movement package integration:**

* Added `from_movement` function and `MovementDataset` class to `pynapple.io.movement`, enabling conversion of movement `xarray.Dataset` objects (poses/bboxes) into Pynapple time series objects, with validation, multi-individual support, and a rich preview table.
* Registered `from_movement` in the Pynapple IO API (`pynapple/io/__init__.py`).

**Testing and documentation:**

* Added comprehensive tests for the new interface, covering validation, single/multiple individual datasets, lazy loading, and preview table output (`tests/test_movement.py`).
* Provided a minimal example script demonstrating the workflow from loading movement data to conversion and inspection in Pynapple (`movement_example.py`).