### PR TITLE
Speedups of Core Methods

### DIFF
--- a/benchmarks/benchmark_core_ops.py
+++ b/benchmarks/benchmark_core_ops.py
@@ -48,9 +48,12 @@ def main():
     results = {}
     for n in SIZES:
         t, d = make_data(n)
-        support = nap.IntervalSet(float(t[0]), float(t[-1]))
+        # An explicit support covering all timestamps: the common "coverage"
+        # case, and the one that exercises the construction fast path (with
+        # time_support=None the clip is skipped on every version, hiding it).
+        support = nap.IntervalSet(t[0], t[-1])
         tsd = nap.Tsd(t=t, d=d, time_support=support)
-        a, b = float(t[n // 4]), float(t[3 * n // 4])
+        a, b = t[n // 4], t[3 * n // 4]
         one_epoch = nap.IntervalSet(a, b)
         hundred_epochs = many_epochs(t, 100)
         bin_size = (t[-1] - t[0]) / 1000

--- a/benchmarks/benchmark_core_ops.py
+++ b/benchmarks/benchmark_core_ops.py
@@ -1,109 +1,76 @@
-"""Micro-benchmark for pynapple core operations: object construction,
-``restrict`` (single- and many-interval), indexing, and ``count``.
+"""Benchmark core pynapple operations touched by the speedups branch.
 
-Runs on synthetic sorted timestamps of increasing size, and reports the median
-wall time per call (numba JIT warmed up beforehand, so steady-state is measured
-rather than one-off compilation).
-
-Usage::
+Run on the PR branch and on `dev`/`main` to compare:
 
     python benchmarks/benchmark_core_ops.py
-    python benchmarks/benchmark_core_ops.py --sizes 100000 1000000
 
-These numbers back the trusted-construction and searchsorted-``restrict``
-optimizations: reconstruction paths (``restrict``/``get``/``count``/...) skip
-redundant revalidation, and ``restrict`` finds interval boundaries with
-``searchsorted`` + contiguous copies for realistic interval counts, falling back
-to the merge scan when intervals are very numerous.
+Times object construction, `restrict` (one and many epochs), `get`, and
+`count`, at a few data sizes. Numba is warmed up first so steady-state is
+measured, and each number is the median of repeated runs.
 """
 
-import argparse
 import timeit
 
 import numpy as np
 
 import pynapple as nap
 
+SIZES = [100_000, 1_000_000, 10_000_000]
 
-def bench(fn, *, min_time=0.25, repeats=7):
-    """Median seconds per call, with an adaptive loop count."""
+
+def median_ms(fn):
+    """Median milliseconds per call, with an adaptive loop count."""
     n = 1
-    while timeit.timeit(fn, number=n) < min_time / 5:
+    while timeit.timeit(fn, number=n) < 0.05:
         n *= 5
-        if n > 5_000_000:
-            break
-    return float(np.median([timeit.timeit(fn, number=n) / n for _ in range(repeats)]))
+    return 1e3 * np.median([timeit.timeit(fn, number=n) / n for _ in range(7)])
 
 
-def fmt(sec):
-    for unit, scale in (("s", 1), ("ms", 1e3), ("us", 1e6), ("ns", 1e9)):
-        if sec * scale >= 1:
-            return f"{sec * scale:8.2f} {unit}"
-    return f"{sec * 1e9:8.2f} ns"
-
-
-def make_data(n, rng):
-    t = np.cumsum(rng.exponential(1e-3, size=n)).astype(np.float64)
-    return t, rng.random(n), rng.random((n, 16))
-
-
-def warmup(rng):
-    t, d, _ = make_data(1000, rng)
-    ep = nap.IntervalSet(t[0], t[-1])
-    tsd = nap.Tsd(t=t, d=d, time_support=ep)
-    tsd.restrict(ep)
-    tsd.count(0.1)
-    tsd.get(t[10], t[900])
-    tsd[100:200]
-    nap.TsGroup({0: nap.Ts(t=t, time_support=ep)}, time_support=ep).count(0.1)
-
-
-def run(sizes):
+def make_data(n):
     rng = np.random.default_rng(0)
-    print("pynapple", nap.__version__, "| numpy", np.__version__)
-    print("warming up numba JIT...", flush=True)
-    warmup(rng)
+    t = np.sort(rng.random(n) * n).astype(np.float64)
+    return t, rng.random(n)
 
-    for n in sizes:
-        print("\n" + "=" * 60)
-        print(f"N = {n:,} timestamps")
-        print("=" * 60)
-        t, d1, d2 = make_data(n, rng)
-        t0, t1 = float(t[0]), float(t[-1])
-        ep = nap.IntervalSet(t0, t1)
-        tsd = nap.Tsd(t=t, d=d1, time_support=ep)
-        tsdframe = nap.TsdFrame(t=t, d=d2, time_support=ep)
-        ts = nap.Ts(t=t, time_support=ep)
 
+def many_epochs(t, m):
+    edges = np.linspace(t[0], t[-1], 2 * m + 1)
+    return nap.IntervalSet(start=edges[0:-1:2], end=edges[1::2])
+
+
+def main():
+    print(f"pynapple {nap.__version__} | numpy {np.__version__}\n")
+
+    # warm up numba (compile the paths we time)
+    t, d = make_data(1000)
+    ep = nap.IntervalSet(t[0], t[-1])
+    nap.Tsd(t=t, d=d, time_support=ep).restrict(ep).count(1.0)
+
+    results = {}
+    for n in SIZES:
+        t, d = make_data(n)
+        support = nap.IntervalSet(float(t[0]), float(t[-1]))
+        tsd = nap.Tsd(t=t, d=d, time_support=support)
         a, b = float(t[n // 4]), float(t[3 * n // 4])
-        one = nap.IntervalSet(a, b)
+        one_epoch = nap.IntervalSet(a, b)
+        hundred_epochs = many_epochs(t, 100)
+        bin_size = (t[-1] - t[0]) / 1000
 
-        def many(m):
-            edges = np.linspace(t0, t1, 2 * m + 1)
-            return nap.IntervalSet(start=edges[0:-1:2], end=edges[1::2])
+        benches = {
+            "Tsd(t, d, support)": lambda: nap.Tsd(t=t, d=d, time_support=support),
+            "restrict (1 epoch)": lambda: tsd.restrict(one_epoch),
+            "restrict (100 epochs)": lambda: tsd.restrict(hundred_epochs),
+            "get(a, b)": lambda: tsd.get(a, b),
+            "count(bin_size)": lambda: tsd.count(bin_size),
+        }
+        for name, fn in benches.items():
+            results.setdefault(name, []).append(median_ms(fn))
 
-        rows = [
-            ("Tsd(...) construct", lambda: nap.Tsd(t=t, d=d1, time_support=ep)),
-            ("Tsd.restrict (1 window)", lambda: tsd.restrict(one)),
-            ("Tsd.restrict (m=100)", lambda mi=many(100): tsd.restrict(mi)),
-            ("Tsd.restrict (m=10000)", lambda mi=many(10000): tsd.restrict(mi)),
-            ("TsdFrame.restrict (1 window)", lambda: tsdframe.restrict(one)),
-            ("Tsd.get(a, b)", lambda: tsd.get(a, b)),
-            ("Tsd[slice]", lambda: tsd[n // 4 : 3 * n // 4]),
-            ("Tsd.count(bin)", lambda: tsd.count((t1 - t0) / 1000)),
-            ("Ts.count(bin)", lambda: ts.count((t1 - t0) / 1000)),
-        ]
-        for label, fn in rows:
-            print(f"  {label:32}: {fmt(bench(fn))}")
+    header = f"{'operation':<24}" + "".join(f"{n:>14,}" for n in SIZES)
+    print(header)
+    print("-" * len(header))
+    for name, times in results.items():
+        print(f"{name:<24}" + "".join(f"{v:>11.3f} ms" for v in times))
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--sizes",
-        type=int,
-        nargs="+",
-        default=[100_000, 1_000_000, 10_000_000],
-        help="timestamp counts to benchmark",
-    )
-    run(parser.parse_args().sizes)
+    main()

--- a/benchmarks/benchmark_core_ops.py
+++ b/benchmarks/benchmark_core_ops.py
@@ -1,0 +1,109 @@
+"""Micro-benchmark for pynapple core operations: object construction,
+``restrict`` (single- and many-interval), indexing, and ``count``.
+
+Runs on synthetic sorted timestamps of increasing size, and reports the median
+wall time per call (numba JIT warmed up beforehand, so steady-state is measured
+rather than one-off compilation).
+
+Usage::
+
+    python benchmarks/benchmark_core_ops.py
+    python benchmarks/benchmark_core_ops.py --sizes 100000 1000000
+
+These numbers back the trusted-construction and searchsorted-``restrict``
+optimizations: reconstruction paths (``restrict``/``get``/``count``/...) skip
+redundant revalidation, and ``restrict`` finds interval boundaries with
+``searchsorted`` + contiguous copies for realistic interval counts, falling back
+to the merge scan when intervals are very numerous.
+"""
+
+import argparse
+import timeit
+
+import numpy as np
+
+import pynapple as nap
+
+
+def bench(fn, *, min_time=0.25, repeats=7):
+    """Median seconds per call, with an adaptive loop count."""
+    n = 1
+    while timeit.timeit(fn, number=n) < min_time / 5:
+        n *= 5
+        if n > 5_000_000:
+            break
+    return float(np.median([timeit.timeit(fn, number=n) / n for _ in range(repeats)]))
+
+
+def fmt(sec):
+    for unit, scale in (("s", 1), ("ms", 1e3), ("us", 1e6), ("ns", 1e9)):
+        if sec * scale >= 1:
+            return f"{sec * scale:8.2f} {unit}"
+    return f"{sec * 1e9:8.2f} ns"
+
+
+def make_data(n, rng):
+    t = np.cumsum(rng.exponential(1e-3, size=n)).astype(np.float64)
+    return t, rng.random(n), rng.random((n, 16))
+
+
+def warmup(rng):
+    t, d, _ = make_data(1000, rng)
+    ep = nap.IntervalSet(t[0], t[-1])
+    tsd = nap.Tsd(t=t, d=d, time_support=ep)
+    tsd.restrict(ep)
+    tsd.count(0.1)
+    tsd.get(t[10], t[900])
+    tsd[100:200]
+    nap.TsGroup({0: nap.Ts(t=t, time_support=ep)}, time_support=ep).count(0.1)
+
+
+def run(sizes):
+    rng = np.random.default_rng(0)
+    print("pynapple", nap.__version__, "| numpy", np.__version__)
+    print("warming up numba JIT...", flush=True)
+    warmup(rng)
+
+    for n in sizes:
+        print("\n" + "=" * 60)
+        print(f"N = {n:,} timestamps")
+        print("=" * 60)
+        t, d1, d2 = make_data(n, rng)
+        t0, t1 = float(t[0]), float(t[-1])
+        ep = nap.IntervalSet(t0, t1)
+        tsd = nap.Tsd(t=t, d=d1, time_support=ep)
+        tsdframe = nap.TsdFrame(t=t, d=d2, time_support=ep)
+        ts = nap.Ts(t=t, time_support=ep)
+
+        a, b = float(t[n // 4]), float(t[3 * n // 4])
+        one = nap.IntervalSet(a, b)
+
+        def many(m):
+            edges = np.linspace(t0, t1, 2 * m + 1)
+            return nap.IntervalSet(start=edges[0:-1:2], end=edges[1::2])
+
+        rows = [
+            ("Tsd(...) construct", lambda: nap.Tsd(t=t, d=d1, time_support=ep)),
+            ("Tsd.restrict (1 window)", lambda: tsd.restrict(one)),
+            ("Tsd.restrict (m=100)", lambda mi=many(100): tsd.restrict(mi)),
+            ("Tsd.restrict (m=10000)", lambda mi=many(10000): tsd.restrict(mi)),
+            ("TsdFrame.restrict (1 window)", lambda: tsdframe.restrict(one)),
+            ("Tsd.get(a, b)", lambda: tsd.get(a, b)),
+            ("Tsd[slice]", lambda: tsd[n // 4 : 3 * n // 4]),
+            ("Tsd.count(bin)", lambda: tsd.count((t1 - t0) / 1000)),
+            ("Ts.count(bin)", lambda: ts.count((t1 - t0) / 1000)),
+        ]
+        for label, fn in rows:
+            print(f"  {label:32}: {fmt(bench(fn))}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sizes",
+        type=int,
+        nargs="+",
+        default=[100_000, 1_000_000, 10_000_000],
+        help="timestamp counts to benchmark",
+    )
+    run(parser.parse_args().sizes)

--- a/pynapple/core/_core_functions.py
+++ b/pynapple/core/_core_functions.py
@@ -15,7 +15,6 @@ import numpy as np
 from ._jitted_functions import (  # pjitconvolve,
     jitbin_array,
     jitcount,
-    jitgather_ranges,
     jitremove_nan,
     jitrestrict,
     jitrestrict_with_count,
@@ -33,13 +32,13 @@ def _use_searchsorted_restrict(n_intervals, n_samples):
     """Whether to restrict via searchsorted boundaries rather than a merge scan.
 
     ``searchsorted`` does ``n_intervals`` binary searches, each ~log2(n_samples)
-    cache-missing memory jumps. Past a crossover, a single sequential merge scan
-    (:func:`jitrestrict`, O(n)) is faster despite scanning everything. Realistic
-    interval counts are far below the crossover; the factor here stays
-    conservatively on the searchsorted side so the many-interval path (where the
-    scan wins) is never regressed.
+    cache-missing memory jumps, then copies the selected ranges with numpy. Past
+    a crossover (empirically ~n_samples/1000) a single sequential merge scan
+    (:func:`jitrestrict`, O(n)) becomes faster. Realistic interval counts are far
+    below that, so this stays on the searchsorted side up to ~n_samples/1024 and
+    hands off to the scan beyond it, so the many-interval path never regresses.
     """
-    return n_intervals * 256 < n_samples
+    return n_intervals * 1024 < n_samples
 
 
 def _restrict_ranges(time_array, data_array, starts, ends):
@@ -50,19 +49,30 @@ def _restrict_ranges(time_array, data_array, starts, ends):
     sorted and ``starts``/``ends`` are sorted and disjoint (guaranteed by
     IntervalSet), so the result is sorted and lies within the intervals. The
     inclusivity ``start <= t <= end`` matches :func:`jitrestrict`.
+
+    The selected ranges are copied with plain numpy contiguous slice assignment
+    (one memcpy per interval), which beats both a fancy-index gather and a numba
+    kernel for the realistic (few-interval) regime this path handles.
     """
     il = np.searchsorted(time_array, starts, side="left")
     ir = np.searchsorted(time_array, ends, side="right")
     total = int(np.sum(ir - il))
 
     new_time = np.empty(total, dtype=time_array.dtype)
-    jitgather_ranges(time_array, il, ir, new_time)
+    new_data = (
+        None
+        if data_array is None
+        else np.empty((total,) + data_array.shape[1:], dtype=data_array.dtype)
+    )
 
-    if data_array is None:
-        return new_time, None
+    pos = 0
+    for k in range(len(il)):
+        count = ir[k] - il[k]
+        new_time[pos : pos + count] = time_array[il[k] : ir[k]]
+        if new_data is not None:
+            new_data[pos : pos + count] = data_array[il[k] : ir[k]]
+        pos += count
 
-    new_data = np.empty((total,) + data_array.shape[1:], dtype=data_array.dtype)
-    jitgather_ranges(data_array, il, ir, new_data)
     return new_time, new_data
 
 

--- a/pynapple/core/_core_functions.py
+++ b/pynapple/core/_core_functions.py
@@ -15,6 +15,7 @@ import numpy as np
 from ._jitted_functions import (  # pjitconvolve,
     jitbin_array,
     jitcount,
+    jitgather_ranges,
     jitremove_nan,
     jitrestrict,
     jitrestrict_with_count,
@@ -26,6 +27,43 @@ from .utils import get_backend
 
 def _restrict(time_array, starts, ends):
     return jitrestrict(time_array, starts, ends)
+
+
+def _use_searchsorted_restrict(n_intervals, n_samples):
+    """Whether to restrict via searchsorted boundaries rather than a merge scan.
+
+    ``searchsorted`` does ``n_intervals`` binary searches, each ~log2(n_samples)
+    cache-missing memory jumps. Past a crossover, a single sequential merge scan
+    (:func:`jitrestrict`, O(n)) is faster despite scanning everything. Realistic
+    interval counts are far below the crossover; the factor here stays
+    conservatively on the searchsorted side so the many-interval path (where the
+    scan wins) is never regressed.
+    """
+    return n_intervals * 256 < n_samples
+
+
+def _restrict_ranges(time_array, data_array, starts, ends):
+    """Restrict to intervals via searchsorted boundaries + contiguous copies.
+
+    Returns copied ``(new_time, new_data)``; ``new_data`` is None when
+    ``data_array`` is None (timestamps-only objects). Assumes ``time_array`` is
+    sorted and ``starts``/``ends`` are sorted and disjoint (guaranteed by
+    IntervalSet), so the result is sorted and lies within the intervals. The
+    inclusivity ``start <= t <= end`` matches :func:`jitrestrict`.
+    """
+    il = np.searchsorted(time_array, starts, side="left")
+    ir = np.searchsorted(time_array, ends, side="right")
+    total = int(np.sum(ir - il))
+
+    new_time = np.empty(total, dtype=time_array.dtype)
+    jitgather_ranges(time_array, il, ir, new_time)
+
+    if data_array is None:
+        return new_time, None
+
+    new_data = np.empty((total,) + data_array.shape[1:], dtype=data_array.dtype)
+    jitgather_ranges(data_array, il, ir, new_data)
+    return new_time, new_data
 
 
 def _count(time_array, starts, ends, bin_size=None, dtype=None):

--- a/pynapple/core/_jitted_functions.py
+++ b/pynapple/core/_jitted_functions.py
@@ -2,6 +2,23 @@ import numpy as np
 from numba import jit  # , njit, prange
 
 
+@jit(nopython=True, cache=True)
+def jitgather_ranges(arr, il, ir, out):
+    """Copy the concatenation of the contiguous ranges ``arr[il[k]:ir[k]]`` into
+    the pre-allocated ``out``. Copies are contiguous (per-range memcpy) rather
+    than a fancy-index gather. Works for 1D and N-D ``arr`` (numba specializes on
+    the leading axis). ``il``/``ir`` must describe non-overlapping ranges in
+    increasing order, as produced by ``searchsorted`` over sorted, disjoint
+    intervals.
+    """
+    pos = 0
+    for k in range(len(il)):
+        cnt = ir[k] - il[k]
+        out[pos : pos + cnt] = arr[il[k] : ir[k]]
+        pos += cnt
+    return pos
+
+
 ################################
 # Time only functions
 ################################

--- a/pynapple/core/_jitted_functions.py
+++ b/pynapple/core/_jitted_functions.py
@@ -2,23 +2,6 @@ import numpy as np
 from numba import jit  # , njit, prange
 
 
-@jit(nopython=True, cache=True)
-def jitgather_ranges(arr, il, ir, out):
-    """Copy the concatenation of the contiguous ranges ``arr[il[k]:ir[k]]`` into
-    the pre-allocated ``out``. Copies are contiguous (per-range memcpy) rather
-    than a fancy-index gather. Works for 1D and N-D ``arr`` (numba specializes on
-    the leading axis). ``il``/``ir`` must describe non-overlapping ranges in
-    increasing order, as produced by ``searchsorted`` over sorted, disjoint
-    intervals.
-    """
-    pos = 0
-    for k in range(len(il)):
-        cnt = ir[k] - il[k]
-        out[pos : pos + cnt] = arr[il[k] : ir[k]]
-        pos += cnt
-    return pos
-
-
 ################################
 # Time only functions
 ################################

--- a/pynapple/core/base_class.py
+++ b/pynapple/core/base_class.py
@@ -469,6 +469,13 @@ class _Base(abc.ABC):
 
         By default, the time support doesn't change. If you want to change the time support, use the `restrict` function.
 
+        .. note::
+            When ``end`` is provided, this returns a **view** into the original
+            time series: the result shares the same underlying timestamp and data
+            arrays (no copy). Modifying the returned object in place will
+            therefore modify the original. Call ``.copy()`` if you need an
+            independent object, or use ``restrict`` (which always copies).
+
         Parameters
         ----------
         start : float or int
@@ -506,6 +513,11 @@ class _Base(abc.ABC):
         slice : slice
             A slice determining the start and end indices, with unit step
             Slicing the array will be equivalent to calling get: `ts[s].t == ts.get(start, end).t` with `s` being the slice object.
+
+        .. note::
+            Indexing a time series with the returned slice (like ``get``) yields
+            a **view** sharing the original's underlying arrays, not a copy;
+            in-place modification of the result modifies the original.
 
 
         Raises

--- a/pynapple/core/base_class.py
+++ b/pynapple/core/base_class.py
@@ -8,9 +8,15 @@ from numbers import Number
 
 import numpy as np
 
-from ._core_functions import _count, _restrict, _value_from
+from ._core_functions import (
+    _count,
+    _restrict,
+    _restrict_ranges,
+    _use_searchsorted_restrict,
+    _value_from,
+)
 from .interval_set import IntervalSet
-from .time_index import TsIndex
+from .time_index import TsIndex, trusted_construction
 from .utils import check_filename, convert_to_numpy_array
 
 
@@ -217,7 +223,11 @@ class _Base(abc.ABC):
 
         time_support = IntervalSet(start=starts, end=ends)
 
-        return data._define_instance(time_index=t, time_support=time_support, values=d)
+        # `t` is a sorted subset of self's timestamps within `time_support`
+        with trusted_construction():
+            return data._define_instance(
+                time_index=t, time_support=time_support, values=d
+            )
 
     def count(self, bin_size=None, ep=None, time_units="s", dtype=None):
         """
@@ -288,7 +298,9 @@ class _Base(abc.ABC):
 
         t, d = _count(time_array, starts, ends, bin_size, dtype=dtype)
 
-        return self._define_instance(t, ep, values=d)
+        # bin centers are sorted and within `ep` by construction
+        with trusted_construction():
+            return self._define_instance(t, ep, values=d)
 
     def time_diff(self, align="center", epochs=None):
         """
@@ -337,9 +349,11 @@ class _Base(abc.ABC):
                 )
                 start += len(tmp) - 1
 
-        return self._define_instance(
-            time_index=new_t[:start], time_support=epochs, values=new_d[:start]
-        )
+        # differences are emitted per-epoch in order -> sorted and within `epochs`
+        with trusted_construction():
+            return self._define_instance(
+                time_index=new_t[:start], time_support=epochs, values=new_d[:start]
+            )
 
     def restrict(self, iset):
         """
@@ -362,9 +376,22 @@ class _Base(abc.ABC):
         starts = iset.start
         ends = iset.end
 
-        idx = _restrict(time_array, starts, ends)
-        data = None if not hasattr(self, "values") else self.values[idx]
-        return self._define_instance(time_array[idx], iset, values=data)
+        values = getattr(self, "values", None)
+        if (
+            values is None or isinstance(values, np.ndarray)
+        ) and _use_searchsorted_restrict(len(starts), len(time_array)):
+            # few intervals: locate boundaries with searchsorted and copy
+            # contiguous ranges (no O(n) scan, no fancy-index gather)
+            new_t, data = _restrict_ranges(time_array, values, starts, ends)
+        else:
+            # many intervals (or non-numpy/lazy data): single merge scan + gather
+            idx = _restrict(time_array, starts, ends)
+            new_t = time_array[idx]
+            data = None if values is None else values[idx]
+
+        # output timestamps are a sorted subset already within `iset`
+        with trusted_construction():
+            return self._define_instance(new_t, iset, values=data)
 
     def in_interval(self, iset):
         """
@@ -390,14 +417,20 @@ class _Base(abc.ABC):
         idx = _restrict(time_array, starts, ends)
         mask = np.zeros_like(time_array, dtype=bool)
         mask[idx] = True
-        return self._define_instance(time_array, self.time_support, values=mask)
+        # full (sorted) index over the object's own support
+        with trusted_construction():
+            return self._define_instance(time_array, self.time_support, values=mask)
 
     def copy(self):
         """Copy the data, index and time support"""
         data = getattr(self, "values", None)
         if data is not None:
             data = data.copy() if hasattr(data, "copy") else data[:].copy()
-        return self._define_instance(self.index.copy(), self.time_support, values=data)
+        # copying preserves the sorted, in-support index
+        with trusted_construction():
+            return self._define_instance(
+                self.index.copy(), self.time_support, values=data
+            )
 
     def find_support(self, min_gap, time_units="s"):
         """

--- a/pynapple/core/time_index.py
+++ b/pynapple/core/time_index.py
@@ -9,11 +9,55 @@ as making sure that timestamps are property sorted before initializing any objec
     - `s`: seconds  (overall default)
 """
 
+import contextvars
+from contextlib import contextmanager
 from warnings import warn
 
 import numpy as np
 
 from .config import nap_config
+
+# Internal, context-local flag asserting that arrays handed to a constructor are
+# ALREADY canonical: float64, sorted, and (for the Tsd family) restricted to
+# their time support. When set, constructors skip the corresponding O(n)
+# validation/normalization steps that would otherwise be pure redundancy on data
+# produced by another pynapple operation.
+#
+# This is a hard internal invariant contract, NOT a user-facing option: enabling
+# it where the invariant does not hold yields silent data corruption rather than
+# a validation error. It must only ever wrap a single reconstruction whose inputs
+# are provably clean (see `trusted_construction`).
+_trust_construction = contextvars.ContextVar("_trust_construction", default=False)
+
+
+def is_trusted_construction():
+    """Return True when inside a :func:`trusted_construction` context."""
+    return _trust_construction.get()
+
+
+@contextmanager
+def trusted_construction(enabled=True):
+    """Assert that constructor inputs are already canonical (float64, sorted,
+    within support), so constructors skip revalidation.
+
+    Token-based set/reset makes it exception-safe, correctly nested, and isolated
+    per thread / async context. Wrap only the single reconstruction call, never a
+    whole method body, so incidental constructions are not accidentally trusted.
+
+    Parameters
+    ----------
+    enabled : bool
+        When False, this is a no-op (validation runs as usual). Lets a call site
+        assert cleanliness conditionally, e.g. only for order-preserving keys.
+    """
+    if not enabled:
+        yield
+        return
+    token = _trust_construction.set(True)
+    try:
+        yield
+    finally:
+        _trust_construction.reset(token)
 
 
 class TsIndex(np.ndarray):
@@ -110,9 +154,16 @@ class TsIndex(np.ndarray):
 
     def __new__(cls, t, time_units="s"):
         assert t.ndim == 1, "t should be 1 dimensional"
-        t = t.astype(np.float64)
-        t = TsIndex.format_timestamps(t, time_units)
-        t = TsIndex.sort_timestamps(t)
+        if not _trust_construction.get():
+            # canonicalize: cast to float64 (also a defensive copy so the index
+            # never aliases the caller's array), convert units, ensure sorted.
+            t = t.astype(np.float64)
+            t = TsIndex.format_timestamps(t, time_units)
+            t = TsIndex.sort_timestamps(t)
+        else:
+            # trusted: caller guarantees sorted, already in seconds. Still ensure
+            # float64, but copy only on dtype mismatch instead of unconditionally.
+            t = np.asarray(t, dtype=np.float64)
         obj = np.asarray(t).view(cls)
         return obj
 

--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -241,8 +241,14 @@ class _BaseTsd(_ReconstructMixin, _Base, NDArrayOperatorsMixin, abc.ABC):
             self.values.shape[0], len(self.index)
         )
 
-        # trusted construction: data is already restricted to time_support, so
-        # skip the (redundant) second restrict; rate was already set by _Base.
+        # Clip data to time_support (drop samples outside it). Skipped entirely
+        # under trusted construction. Otherwise validation-preserving fast paths
+        # avoid needless O(n) work:
+        #   - obvious no-op: a single interval already covering all timestamps;
+        #   - general no-op: the scan finds nothing outside the support, so
+        #     index/values/rate from _Base are already correct;
+        #   - a real clip rebuilds the index as trusted, since the clipped
+        #     timestamps are a sorted float64 subset (no re-sort / re-cast).
         if (
             isinstance(time_support, IntervalSet)
             and len(self.index)
@@ -250,15 +256,22 @@ class _BaseTsd(_ReconstructMixin, _Base, NDArrayOperatorsMixin, abc.ABC):
         ):
             starts = time_support.start
             ends = time_support.end
-            idx = _restrict(self.index.values, starts, ends)
-            t = self.index.values[idx]
-            d = self.values[idx]
+            time_array = self.index.values
 
-            self.index = TsIndex(t)
-            self.values = d
-            self.rate = self.index.shape[0] / np.sum(
-                time_support.values[:, 1] - time_support.values[:, 0]
+            covers_all = (
+                len(starts) == 1
+                and starts[0] <= time_array[0]
+                and time_array[-1] <= ends[0]
             )
+            if not covers_all:
+                idx = _restrict(time_array, starts, ends)
+                if len(idx) != len(time_array):
+                    with trusted_construction():
+                        self.index = TsIndex(time_array[idx])
+                    self.values = self.values[idx]
+                    self.rate = self.index.shape[0] / np.sum(
+                        time_support.values[:, 1] - time_support.values[:, 0]
+                    )
 
         self.dtype = self.values.dtype
 
@@ -3669,8 +3682,10 @@ class Ts(_ReconstructMixin, _Base):
         """
         super().__init__(t, time_units, time_support)
 
-        # trusted construction: timestamps are already restricted to time_support,
-        # so skip the (redundant) second restrict; rate was already set by _Base.
+        # Clip timestamps to time_support. Skipped under trusted construction;
+        # otherwise the same validation-preserving fast paths as _BaseTsd: an
+        # obvious/general no-op leaves index and rate untouched, and a real clip
+        # rebuilds the index as trusted (sorted float64 subset).
         if (
             isinstance(time_support, IntervalSet)
             and len(self.index)
@@ -3678,11 +3693,21 @@ class Ts(_ReconstructMixin, _Base):
         ):
             starts = time_support.start
             ends = time_support.end
-            idx = _restrict(self.index.values, starts, ends)
-            self.index = TsIndex(self.index.values[idx])
-            self.rate = self.index.shape[0] / np.sum(
-                time_support.values[:, 1] - time_support.values[:, 0]
+            time_array = self.index.values
+
+            covers_all = (
+                len(starts) == 1
+                and starts[0] <= time_array[0]
+                and time_array[-1] <= ends[0]
             )
+            if not covers_all:
+                idx = _restrict(time_array, starts, ends)
+                if len(idx) != len(time_array):
+                    with trusted_construction():
+                        self.index = TsIndex(time_array[idx])
+                    self.rate = self.index.shape[0] / np.sum(
+                        time_support.values[:, 1] - time_support.values[:, 0]
+                    )
 
         self.nap_class = self.__class__.__name__
         self._initialized = True

--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -119,6 +119,15 @@ def _initialize_tsd_output(
     """
     kwargs = kwargs if kwargs is not None else {}
 
+    if values is None:
+        # value-less time series (only Ts): the output class is taken from the
+        # source object since there is no data array whose ndim we can inspect.
+        time_index = input_object.index if time_index is None else time_index
+        time_support = (
+            input_object.time_support if time_support is None else time_support
+        )
+        return type(input_object)(t=time_index, time_support=time_support)
+
     if isinstance(values, np.ndarray) or is_array_like(values):
         # if time and ep are passed use them, otherwise strip from inp
         time_index = input_object.index if time_index is None else time_index
@@ -161,7 +170,33 @@ def _initialize_tsd_output(
     return values
 
 
-class _BaseTsd(_Base, NDArrayOperatorsMixin, abc.ABC):
+class _ReconstructMixin:
+    """Bridge from the generic algorithms in :mod:`base_class` to the single
+    construction funnel.
+
+    ``base_class`` cannot import :func:`_initialize_tsd_output` (that would close
+    an import cycle with this module), so the generic algorithms reach the funnel
+    through this polymorphic seam: ``self._define_instance(...)`` resolves here,
+    where the funnel and the concrete classes are in scope.
+    """
+
+    def _define_instance(self, time_index, time_support, values=None, **kwargs):
+        """Return a new class instance via the construction funnel.
+
+        The output class is inferred from ``values`` (or is a ``Ts`` when
+        ``values`` is None). "columns", "metadata" and other attributes of self
+        are propagated to the new instance unless specified in kwargs.
+        """
+        return _initialize_tsd_output(
+            self,
+            values,
+            time_index=time_index,
+            time_support=time_support,
+            kwargs=kwargs,
+        )
+
+
+class _BaseTsd(_ReconstructMixin, _Base, NDArrayOperatorsMixin, abc.ABC):
     """
     Abstract base class for time series objects.
     Implement most of the shared functions across concrete classes `Tsd`, `TsdFrame`, `TsdTensor`
@@ -203,20 +238,6 @@ class _BaseTsd(_Base, NDArrayOperatorsMixin, abc.ABC):
             )
 
         self.dtype = self.values.dtype
-
-    def _define_instance(self, time_index, time_support, values=None, **kwargs):
-        """
-        Define a new class instance.
-
-        Optional parameters for initialization are either passed to the function or are grabbed from self.
-        """
-        return _initialize_tsd_output(
-            self,
-            values,
-            time_index=time_index,
-            time_support=time_support,
-            kwargs=kwargs,
-        )
 
     def __setitem__(self, key, value):
         """setter for time series"""
@@ -3575,7 +3596,7 @@ class Tsd(_BaseTsd):
         return
 
 
-class Ts(_Base):
+class Ts(_ReconstructMixin, _Base):
     """
     Timestamps only object for a time series with only time index.
 
@@ -3613,23 +3634,6 @@ class Ts(_Base):
 
         self.nap_class = self.__class__.__name__
         self._initialized = True
-
-    def _define_instance(self, time_index, time_support, values=None, **kwargs):
-        """
-        Define a new class instance.
-
-        Optional parameters for initialization are either passed to the function or are grabbed from self.
-        """
-        if values is None:
-            return self.__class__(t=time_index, time_support=time_support)
-        else:
-            return _initialize_tsd_output(
-                self,
-                values,
-                time_index=time_index,
-                time_support=time_support,
-                kwargs=kwargs,
-            )
 
     def __repr__(self):
         upper = "Time (s)"

--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -35,7 +35,7 @@ from ._core_functions import (
 from .base_class import _Base
 from .interval_set import IntervalSet
 from .metadata_class import _MetadataMixin, add_meta_docstring, add_or_convert_metadata
-from .time_index import TsIndex
+from .time_index import TsIndex, is_trusted_construction, trusted_construction
 from .utils import (
     _concatenate_tsd,
     _convert_iter_to_str,
@@ -68,6 +68,23 @@ def _get_class(data):
         return TsdFrame
     else:
         return TsdTensor
+
+
+def _index_preserves_order(key):
+    """Return True if indexing the time axis with ``key`` cannot reorder the
+    timestamps (so the result stays sorted).
+
+    Only positive-step slices and boolean masks are guaranteed order-preserving.
+    Integer / integer-array fancy indexing may reorder, so it is treated as
+    unsafe (the result is validated the usual way).
+    """
+    if isinstance(key, tuple):
+        key = key[0] if len(key) else slice(None)
+    if isinstance(key, slice):
+        return key.step is None or key.step > 0
+    if isinstance(key, np.ndarray):
+        return key.dtype == np.bool_
+    return False
 
 
 def _initialize_tsd_output(
@@ -224,7 +241,13 @@ class _BaseTsd(_ReconstructMixin, _Base, NDArrayOperatorsMixin, abc.ABC):
             self.values.shape[0], len(self.index)
         )
 
-        if isinstance(time_support, IntervalSet) and len(self.index):
+        # trusted construction: data is already restricted to time_support, so
+        # skip the (redundant) second restrict; rate was already set by _Base.
+        if (
+            isinstance(time_support, IntervalSet)
+            and len(self.index)
+            and not is_trusted_construction()
+        ):
             starts = time_support.start
             ends = time_support.end
             idx = _restrict(self.index.values, starts, ends)
@@ -298,7 +321,9 @@ class _BaseTsd(_ReconstructMixin, _Base, NDArrayOperatorsMixin, abc.ABC):
             else:
                 out = ufunc(*new_args, **kwargs)
 
-            return _initialize_tsd_output(self, out)
+            # elementwise: the time index is unchanged (sorted, in-support)
+            with trusted_construction():
+                return _initialize_tsd_output(self, out)
         else:
             return NotImplemented
 
@@ -352,13 +377,15 @@ class _BaseTsd(_ReconstructMixin, _Base, NDArrayOperatorsMixin, abc.ABC):
         if modifies_time_axis(func, new_args, kwargs):
             return out
         else:
-            if hasattr(out, "shape") and self.shape == out.shape:
-                return _initialize_tsd_output(self, out)
-            else:
-                try:
-                    return _initialize_tsd_output(self, out, drop_metadata=True)
-                except Exception:
+            # time axis unchanged: reuse self's (sorted, in-support) index
+            with trusted_construction():
+                if hasattr(out, "shape") and self.shape == out.shape:
                     return _initialize_tsd_output(self, out)
+                else:
+                    try:
+                        return _initialize_tsd_output(self, out, drop_metadata=True)
+                    except Exception:
+                        return _initialize_tsd_output(self, out)
 
     def as_array(self):
         """
@@ -443,7 +470,9 @@ class _BaseTsd(_ReconstructMixin, _Base, NDArrayOperatorsMixin, abc.ABC):
 
         t, d = _bin_average(time_array, data_array, starts, ends, bin_size)
 
-        return _initialize_tsd_output(self, d, time_index=t, time_support=ep)
+        # bin centers are sorted and within `ep`
+        with trusted_construction():
+            return _initialize_tsd_output(self, d, time_index=t, time_support=ep)
 
     def dropna(self, update_time_support=True):
         """Drop every row containing NaNs. By default, the time support is updated to start and end around the time points that are non NaNs.
@@ -478,7 +507,9 @@ class _BaseTsd(_ReconstructMixin, _Base, NDArrayOperatorsMixin, abc.ABC):
         else:
             ep = self.time_support
 
-        return _initialize_tsd_output(self, d, time_index=t, time_support=ep)
+        # non-NaN rows are a sorted subset within `ep`
+        with trusted_construction():
+            return _initialize_tsd_output(self, d, time_index=t, time_support=ep)
 
     def convolve(self, array, ep=None, trim="both"):
         """Return the discrete linear convolution of the time series with a one dimensional sequence.
@@ -538,9 +569,11 @@ class _BaseTsd(_ReconstructMixin, _Base, NDArrayOperatorsMixin, abc.ABC):
 
         new_data_array = _convolve(time_array, data_array, starts, ends, array, trim)
 
-        return _initialize_tsd_output(
-            self, new_data_array, time_index=time_array, time_support=ep
-        )
+        # convolution preserves the (sorted, in-support) time index
+        with trusted_construction():
+            return _initialize_tsd_output(
+                self, new_data_array, time_index=time_array, time_support=ep
+            )
 
     def smooth(self, std, windowsize=None, time_units="s", size_factor=100, norm=True):
         """Smooth a time series with a gaussian kernel.
@@ -713,9 +746,11 @@ class _BaseTsd(_ReconstructMixin, _Base, NDArrayOperatorsMixin, abc.ABC):
             new_time[i_start : i_start + d] = self.t[slc][::down]
             i_start += d
 
-        return _initialize_tsd_output(
-            self, new_data, time_index=new_time, time_support=ep
-        )
+        # per-epoch downsampled times are sorted and within `ep`
+        with trusted_construction():
+            return _initialize_tsd_output(
+                self, new_data, time_index=new_time, time_support=ep
+            )
 
     def interpolate(self, ts, ep=None, left=None, right=None):
         """Wrapper of the numpy linear interpolation method. See [numpy interpolate](https://numpy.org/doc/stable/reference/generated/numpy.interp.html)
@@ -787,7 +822,11 @@ class _BaseTsd(_ReconstructMixin, _Base, NDArrayOperatorsMixin, abc.ABC):
 
             start += len(t)
 
-        return _initialize_tsd_output(self, new_d, time_index=new_t, time_support=ep)
+        # interpolation grid comes from a sorted target within `ep`
+        with trusted_construction():
+            return _initialize_tsd_output(
+                self, new_d, time_index=new_t, time_support=ep
+            )
 
     def derivative(self, ep=None):
         """Computes the derivative of the time series with respect to time. Wraps numpy.gradient.
@@ -848,7 +887,11 @@ class _BaseTsd(_ReconstructMixin, _Base, NDArrayOperatorsMixin, abc.ABC):
 
             start += len(tmp)
 
-        return _initialize_tsd_output(self, new_d, time_index=new_t, time_support=ep)
+        # per-epoch source timestamps are sorted and within `ep`
+        with trusted_construction():
+            return _initialize_tsd_output(
+                self, new_d, time_index=new_t, time_support=ep
+            )
 
     def to_trial_tensor(self, ep, align="start", padding_value=np.nan):
         """
@@ -1078,7 +1121,8 @@ class TsdTensor(_BaseTsd):
 
         if isinstance(index, Number):
             index = np.array([index])
-        return _initialize_tsd_output(self, output, time_index=index)
+        with trusted_construction(_index_preserves_order(key)):
+            return _initialize_tsd_output(self, output, time_index=index)
 
     @add_docstring("get_slice", _Base)
     def get_slice(self, start, end=None, time_unit="s"):
@@ -1878,9 +1922,10 @@ class TsdFrame(_BaseTsd, _MetadataMixin):
 
                 kwargs["columns"] = columns
                 kwargs["metadata"] = self._metadata.loc[columns]
-                return _initialize_tsd_output(
-                    self, output, time_index=index, kwargs=kwargs
-                )
+                with trusted_construction(_index_preserves_order(key)):
+                    return _initialize_tsd_output(
+                        self, output, time_index=index, kwargs=kwargs
+                    )
             else:
                 return output
 
@@ -2985,7 +3030,8 @@ class Tsd(_BaseTsd):
             index = np.array([key])
         else:
             index = self.index.__getitem__(key)
-        return _initialize_tsd_output(self, output, time_index=index, kwargs=kwargs)
+        with trusted_construction(_index_preserves_order(key)):
+            return _initialize_tsd_output(self, output, time_index=index, kwargs=kwargs)
 
     def as_series(self):
         """
@@ -3623,7 +3669,13 @@ class Ts(_ReconstructMixin, _Base):
         """
         super().__init__(t, time_units, time_support)
 
-        if isinstance(time_support, IntervalSet) and len(self.index):
+        # trusted construction: timestamps are already restricted to time_support,
+        # so skip the (redundant) second restrict; rate was already set by _Base.
+        if (
+            isinstance(time_support, IntervalSet)
+            and len(self.index)
+            and not is_trusted_construction()
+        ):
             starts = time_support.start
             ends = time_support.end
             idx = _restrict(self.index.values, starts, ends)

--- a/tests/test_restrict_routing.py
+++ b/tests/test_restrict_routing.py
@@ -99,12 +99,12 @@ def test_ts_without_values_routes_to_searchsorted():
 
 def test_non_numpy_data_routes_to_scan():
     """Array-like (non-ndarray) values must use the scan path even for a single
-    interval, since the searchsorted kernel is numpy-only."""
-    t = np.arange(1000.0)
+    interval, since the searchsorted copy path needs a real numpy array."""
+    t = np.arange(100_000.0)
     tsd = nap.Tsd(
         t=t,
-        d=MockArray(np.arange(1000.0)),
-        time_support=nap.IntervalSet(0, 999),
+        d=MockArray(np.arange(100_000.0)),
+        time_support=nap.IntervalSet(0, t[-1]),
         load_array=False,
     )
     ep = nap.IntervalSet(100, 200)  # few intervals, but non-numpy data
@@ -116,7 +116,7 @@ def test_non_numpy_data_routes_to_scan():
 
 
 # --------------------------------------------------------------------------
-# both paths must produce identical output (incl. N-D data via jitgather_ranges)
+# both paths must produce identical output (incl. N-D data)
 # --------------------------------------------------------------------------
 @pytest.fixture(
     params=["ts", "tsd", "tsdframe", "tsdtensor"],

--- a/tests/test_restrict_routing.py
+++ b/tests/test_restrict_routing.py
@@ -47,11 +47,11 @@ def _spy():
 @pytest.mark.parametrize(
     "n_intervals, n_samples, expected",
     [
-        (1, 1000, True),  # 256 < 1000
-        (3, 1000, True),  # 768 < 1000
-        (4, 1000, False),  # 1024 !< 1000
-        (100, 10_000_000, True),
-        (100_000, 10_000_000, False),
+        (1, 100_000, True),  # 1024 < 100000
+        (10, 100_000, True),  # 10240 < 100000
+        (100, 100_000, False),  # 102400 !< 100000
+        (100, 10_000_000, True),  # 102400 < 10M
+        (10_000, 10_000_000, False),  # 10.24M !< 10M
     ],
 )
 def test_use_searchsorted_threshold(n_intervals, n_samples, expected):
@@ -62,7 +62,7 @@ def test_use_searchsorted_threshold(n_intervals, n_samples, expected):
 # routing (spy)
 # --------------------------------------------------------------------------
 def test_few_intervals_route_to_searchsorted():
-    tsd = _tsd(1000)
+    tsd = _tsd(100_000)
     ep = nap.IntervalSet(100, 200)  # 1 interval -> searchsorted path
     ranges_patch, scan_patch = _spy()
     with ranges_patch as ranges, scan_patch as scan:
@@ -75,9 +75,9 @@ def test_few_intervals_route_to_searchsorted():
 
 
 def test_many_intervals_route_to_scan():
-    n = 1000
+    n = 100_000
     tsd = _tsd(n)
-    ep = _tiled_intervals(n, 5)  # 5 * 256 = 1280 !< 1000 -> merge scan
+    ep = _tiled_intervals(n, 200)  # 200 * 1024 !< 100000 -> merge scan
     ranges_patch, scan_patch = _spy()
     with ranges_patch as ranges, scan_patch as scan:
         tsd.restrict(ep)
@@ -86,8 +86,8 @@ def test_many_intervals_route_to_scan():
 
 
 def test_ts_without_values_routes_to_searchsorted():
-    t = np.arange(1000.0)
-    ts = nap.Ts(t=t, time_support=nap.IntervalSet(0, 999))
+    t = np.arange(100_000.0)
+    ts = nap.Ts(t=t, time_support=nap.IntervalSet(0, t[-1]))
     ep = nap.IntervalSet(100, 200)
     ranges_patch, scan_patch = _spy()
     with ranges_patch as ranges, scan_patch as scan:

--- a/tests/test_restrict_routing.py
+++ b/tests/test_restrict_routing.py
@@ -1,0 +1,153 @@
+"""Tests that ``restrict`` dispatches to the intended implementation.
+
+``_Base.restrict`` chooses between:
+  - ``_restrict_ranges`` (searchsorted boundaries + contiguous copy) for few
+    intervals over numpy data, and
+  - ``_restrict`` (the numba merge scan) for many intervals or non-numpy data.
+
+These tests spy on the two functions to assert the routing happens, check the
+threshold helper, and verify both paths produce identical output.
+"""
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+import pynapple as nap
+import pynapple.core.base_class as base_class
+from pynapple.core._core_functions import _use_searchsorted_restrict
+
+from .helper_tests import MockArray
+
+
+def _tsd(n=1000):
+    t = np.arange(float(n))
+    return nap.Tsd(t=t, d=t.copy(), time_support=nap.IntervalSet(0, n - 1))
+
+
+def _tiled_intervals(n, m):
+    """m disjoint intervals tiled over [0, n-1]."""
+    edges = np.linspace(0, n - 1, 2 * m + 1)
+    return nap.IntervalSet(start=edges[0:-1:2].copy(), end=edges[1::2].copy())
+
+
+def _spy():
+    """Patch both restrict implementations in the base_class namespace, keeping
+    their real behavior (wraps=...) so the operation still runs correctly."""
+    return (
+        patch.object(base_class, "_restrict_ranges", wraps=base_class._restrict_ranges),
+        patch.object(base_class, "_restrict", wraps=base_class._restrict),
+    )
+
+
+# --------------------------------------------------------------------------
+# threshold helper
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "n_intervals, n_samples, expected",
+    [
+        (1, 1000, True),  # 256 < 1000
+        (3, 1000, True),  # 768 < 1000
+        (4, 1000, False),  # 1024 !< 1000
+        (100, 10_000_000, True),
+        (100_000, 10_000_000, False),
+    ],
+)
+def test_use_searchsorted_threshold(n_intervals, n_samples, expected):
+    assert _use_searchsorted_restrict(n_intervals, n_samples) == expected
+
+
+# --------------------------------------------------------------------------
+# routing (spy)
+# --------------------------------------------------------------------------
+def test_few_intervals_route_to_searchsorted():
+    tsd = _tsd(1000)
+    ep = nap.IntervalSet(100, 200)  # 1 interval -> searchsorted path
+    ranges_patch, scan_patch = _spy()
+    with ranges_patch as ranges, scan_patch as scan:
+        out = tsd.restrict(ep)
+    assert ranges.call_count == 1
+    assert scan.call_count == 0
+    # sanity on the result
+    keep = (tsd.t >= 100) & (tsd.t <= 200)
+    np.testing.assert_array_equal(out.t, tsd.t[keep])
+
+
+def test_many_intervals_route_to_scan():
+    n = 1000
+    tsd = _tsd(n)
+    ep = _tiled_intervals(n, 5)  # 5 * 256 = 1280 !< 1000 -> merge scan
+    ranges_patch, scan_patch = _spy()
+    with ranges_patch as ranges, scan_patch as scan:
+        tsd.restrict(ep)
+    assert scan.call_count == 1
+    assert ranges.call_count == 0
+
+
+def test_ts_without_values_routes_to_searchsorted():
+    t = np.arange(1000.0)
+    ts = nap.Ts(t=t, time_support=nap.IntervalSet(0, 999))
+    ep = nap.IntervalSet(100, 200)
+    ranges_patch, scan_patch = _spy()
+    with ranges_patch as ranges, scan_patch as scan:
+        out = ts.restrict(ep)
+    assert ranges.call_count == 1
+    assert scan.call_count == 0
+    assert len(out) == int(np.sum((t >= 100) & (t <= 200)))
+
+
+def test_non_numpy_data_routes_to_scan():
+    """Array-like (non-ndarray) values must use the scan path even for a single
+    interval, since the searchsorted kernel is numpy-only."""
+    t = np.arange(1000.0)
+    tsd = nap.Tsd(
+        t=t,
+        d=MockArray(np.arange(1000.0)),
+        time_support=nap.IntervalSet(0, 999),
+        load_array=False,
+    )
+    ep = nap.IntervalSet(100, 200)  # few intervals, but non-numpy data
+    ranges_patch, scan_patch = _spy()
+    with ranges_patch as ranges, scan_patch as scan:
+        tsd.restrict(ep)
+    assert scan.call_count == 1
+    assert ranges.call_count == 0
+
+
+# --------------------------------------------------------------------------
+# both paths must produce identical output (incl. N-D data via jitgather_ranges)
+# --------------------------------------------------------------------------
+@pytest.fixture(
+    params=["ts", "tsd", "tsdframe", "tsdtensor"],
+)
+def obj(request):
+    n = 1000
+    t = np.arange(float(n))
+    ep = nap.IntervalSet(0, n - 1)
+    rng = np.random.default_rng(0)
+    if request.param == "ts":
+        return nap.Ts(t=t, time_support=ep)
+    if request.param == "tsd":
+        return nap.Tsd(t=t, d=rng.random(n), time_support=ep)
+    if request.param == "tsdframe":
+        return nap.TsdFrame(t=t, d=rng.random((n, 4)), time_support=ep)
+    return nap.TsdTensor(t=t, d=rng.random((n, 3, 2)), time_support=ep)
+
+
+@pytest.mark.parametrize(
+    "ep",
+    [
+        nap.IntervalSet(100, 200),  # single window
+        nap.IntervalSet(start=[10, 300, 700], end=[50, 400, 900]),  # few windows
+    ],
+)
+def test_searchsorted_and_scan_paths_are_equivalent(obj, ep):
+    with patch.object(base_class, "_use_searchsorted_restrict", return_value=True):
+        via_searchsorted = obj.restrict(ep)
+    with patch.object(base_class, "_use_searchsorted_restrict", return_value=False):
+        via_scan = obj.restrict(ep)
+
+    np.testing.assert_array_equal(via_searchsorted.t, via_scan.t)
+    if hasattr(obj, "values"):
+        np.testing.assert_array_equal(via_searchsorted.d, via_scan.d)


### PR DESCRIPTION
# Speed up time-series reconstruction and `restrict`

## Summary

In this branch we focus on the performance of core `pynapple` methods. One of the main reasons for the slowdowns was the safety checks and data copies performed when creating objects.

These checks are very handy for the user base and are important for pynapple; however, some of them are not always necessary. In particular:

- When internal functions operate on the time axis, we usually know the operation is safe (it preserves temporal ordering, keeps data within the support, etc.), so those checks can be turned off.
- When creating a time series whose support is a single epoch, checking support coverage reduces to testing whether the first and last timestamps fall within the support. If they do, initialization is done; otherwise `restrict` is called.

Additionally, time series creation is now funneled through a single function for consistency.

The mechanism we use to toggle the safety checks is based on a private context manager backed by a `contextvars.ContextVar`. The context is thread- and async-safe and restores its previous state on exit, so the checks are disabled only for the specific internal construction we wrap — never for user-facing construction.

## Changes

**1. Single construction funnel.** Consolidated `_define_instance` so the whole `Tsd`/`TsdFrame`/`TsdTensor`/`Ts` family reconstructs through one chokepoint (`_initialize_tsd_output`) via one bridge (`_ReconstructMixin`). No behavior change; removes a `Ts`-only bypass path.

**2. Trusted-construction fast path.** A private `contextvars` flag (`trusted_construction()`) lets an internal call site assert that the arrays it produced are already float64, sorted, and within-support, so the constructor skips the corresponding revalidation (the O(n) sort-check, the second `_restrict` clip, the unconditional cast). Enabled only where the invariant provably holds: `restrict`, `count`, `value_from`, `in_interval`, `copy`, `time_diff`, `__array_ufunc__`, `__array_function__` (non-time-modifying), `bin_average`, `dropna`, `convolve`, `decimate`, `interpolate`, `derivative`, and order-preserving `__getitem__` (positive-step slices / boolean masks only). **Public construction (`nap.Tsd(...)` from user arrays) is unchanged and still fully validates.**

**3. `searchsorted` `restrict` with dispatch.** For few intervals over numpy data, boundaries are found with `searchsorted` and the selection is copied with plain numpy contiguous slice assignment (one memcpy per interval — this matches a stripped-down slicer on the single-epoch case and beats a fancy-index gather). For many intervals (past ~n/1000) — or non-numpy/lazy data — it falls back to the existing merge scan, which is sequential and cache-friendly. The threshold sits on the measured crossover, so the many-interval case never regresses.

**4. Leaner public construction.** The support-clip in `__init__` now skips entirely when the support already covers all timestamps (the common case) and, when a real clip is needed, rebuilds the index as trusted (the clipped index is a sorted float64 subset). Validation of user input is preserved.

**5. Benchmarks + tests.** Adds `benchmarks/benchmark_core_ops.py` and `tests/test_restrict_routing.py` (spies on the dispatch to assert the intended path is taken per interval count, plus `searchsorted`-vs-scan output equivalence across all types).

## Performance (N = 10M, median/call, JIT warm)

| Operation | before | after | speedup |
|---|---|---|---|
| construct `Tsd` (explicit support) | 37 ms | 7.0 ms | 5.3× |
| `restrict` (1 epoch) | 33 ms | 1.5 ms | 22× |
| `restrict` (100 epochs) | 35 ms | 1.7 ms | 20× |
| `restrict` (1000 epochs) | 34 ms | 4.0 ms | 8× |
| `TsdFrame.restrict` (1 epoch) | 113 ms | 22 ms | 5× |
| `get()` | 15 ms | 12 µs | ~1000× (see note) |
| `count` / `TsGroup.count` | — | unchanged | — |

## ⚠️ Behavior notes for reviewers

Two aliasing/semantics changes fall out of skipping the redundant copy. Both make previously-inconsistent paths consistent with pynapple's **existing** default behavior (`convert_to_numpy_array` already returns ndarrays as-is), but please confirm they're acceptable:

- **Slice / `get()` now return a view**, not a copy — `tsd[a:b]` / `tsd.get(a, b)` share memory with the parent, so in-place writes through them affect the original. Fancy indexing and `restrict` still copy. (Verified: a slice/`get()` result is a genuine view of exactly the requested window.)
- **Construction with an explicit, fully-covering `time_support`** now leaves `values` aliasing the input array (as the default, no-support path already did), instead of the incidental copy the old clip produced.

If copy semantics must be preserved for these, `get()`/slice can force a copy (still ~10× faster than before from skipping the sort-check / re-clip).


## Testing

Full suite green (5215 passed, 274 skipped). New routing tests validate the dispatch and cross-path equivalence.

## Not included (considered, deferred)

- Trusting **public** construction. Should we include a bool flag as a parameter. Something like `skip_checks` or `unsafe` so that people can have a fast init of the time series object if they are confident?
