### PR TITLE
adding claude skills info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,20 @@ git clone https://github.com/<username>/pynapple.git
 git remote add upstream https://github.com/pynapple-org/pynapple
 ```
 
+## AI coding assistants
+
+If you contribute with [Claude Code](https://claude.com/claude-code), we maintain a skill that teaches it the
+conventions used throughout this codebase, which helps keep contributions consistent with the rest of the library:
+
+```
+/plugin marketplace add pynapple-org/claude-skills
+/plugin install using-pynapple@pynapple-skills
+/reload-plugins
+```
+
+If a pull request changes a public API signature, please also open an issue on
+[pynapple-org/claude-skills](https://github.com/pynapple-org/claude-skills/issues) so the skill can be kept in sync.
+
 ## Git workflow
 
 In general, we recommend developing changes on feature branches, and then opening a pull request against the `dev` branch for review.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ Community
 
 To ask any questions or get support for using pynapple, please consider joining our slack. Please send an email to thepynapple[at]gmail[dot]com to receive an invitation link.
 
+Using pynapple with Claude Code
+-------------------------------
+
+If you write pynapple code with [Claude Code](https://claude.com/claude-code), the
+[pynapple skill](https://github.com/pynapple-org/claude-skills) teaches it the library's idioms, so it reaches for
+`restrict`, `IntervalSet` and `compute_tuning_curves` instead of falling back on pandas-style loops:
+
+```
+/plugin marketplace add pynapple-org/claude-skills
+/plugin install using-pynapple@pynapple-skills
+/reload-plugins
+```
+
+Claude invokes the skill automatically once it detects pynapple code.
+
 Getting Started
 ---------------
 

--- a/doc/examples/tutorial_phase_preferences.md
+++ b/doc/examples/tutorial_phase_preferences.md
@@ -257,7 +257,7 @@ plt.show()
 :::{card}
 Authors
 ^^^
-[Kipp Freud](https://kippfreud.com/)
+Kipp Freud
 
 Guillaume Viejo
 

--- a/doc/examples/tutorial_wavelet_decomposition.md
+++ b/doc/examples/tutorial_wavelet_decomposition.md
@@ -360,7 +360,7 @@ Those events are called sharp-waves ripples, take a look at [the tutorial on sha
 :::{card}
 Authors
 ^^^
-[Kipp Freud](https://kippfreud.com/)
+Kipp Freud
 
 Guillaume Viejo
 

--- a/doc/external.md
+++ b/doc/external.md
@@ -66,3 +66,34 @@ my_tsgroup = to_pynapple_tsgroup(
 
 my_tsgroup.save("my_tsgroup_output.npz")
 ```
+
+## Claude Code skills
+
+[claude-skills](https://github.com/pynapple-org/claude-skills) is a collection of
+[Claude Code](https://claude.com/claude-code) skills for pynapple, maintained by the pynapple developers.
+
+Large language models tend to write neurophysiology code the way they write pandas code: manual binning loops,
+`.loc` indexing, and time alignment done by hand. The `using-pynapple` skill teaches Claude the library's own
+idioms instead, covering:
+
+- the core data structures (`Ts`, `Tsd`, `TsdFrame`, `TsdTensor`, `TsGroup`, `IntervalSet`)
+- time series manipulation (`restrict`, `count`, `smooth`, `interpolate`, `bin_average`, `derivative`)
+- metadata filtering, tuning curves, and Bayesian and template decoding
+- signal processing (filtering, wavelets), correlograms and perievent analysis
+
+To install it, run the following in Claude Code:
+
+```
+/plugin marketplace add pynapple-org/claude-skills
+/plugin install using-pynapple@pynapple-skills
+/reload-plugins
+```
+
+The skill is invoked automatically whenever Claude detects that it is working with pynapple, so there is nothing
+else to do once it is installed.
+
+```{eval-rst}
+.. Note::
+	This repository derives from `catalystneuro/claude-skills <https://github.com/catalystneuro/claude-skills>`_,
+	which covers the broader neurophysiology ecosystem. The pynapple fork focuses solely on pynapple.
+```

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -60,6 +60,12 @@ pynapple: python neural analysis package
 
             Visualization (pynaviz)
 
+         .. button-link:: https://github.com/pynapple-org/claude-skills
+            :color: primary
+            :shadow:
+
+            Claude Code skills
+
 
 .. grid:: 1 1 6 6
     :gutter: 2

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -30,41 +30,41 @@ pynapple: python neural analysis package
       (spike times, behavioral events, etc.) and time intervals 
       (trials, brain states, etc.). 
 
-      It also provides users with generic functions for 
-      neuroscience such as tuning curves, cross-correlograms 
+      It also provides users with generic functions for
+      neuroscience such as tuning curves, cross-correlograms
       and filtering.
 
-      .. grid:: auto
+.. grid:: auto
 
-         .. button-ref:: installing
-            :color: primary
-            :shadow:
+   .. button-ref:: installing
+      :color: primary
+      :shadow:
 
-            Installing
+      Installing
 
-         .. button-ref:: user_guide/01_introduction_to_pynapple
-            :color: primary
-            :shadow:
+   .. button-ref:: user_guide/01_introduction_to_pynapple
+      :color: primary
+      :shadow:
 
-            Getting started
+      Getting started
 
-         .. button-ref:: citing
-            :color: primary
-            :shadow:
+   .. button-ref:: citing
+      :color: primary
+      :shadow:
 
-            Citing
+      Citing
 
-         .. button-link:: https://pynapple-org.github.io/pynaviz/
-            :color: primary
-            :shadow:
+   .. button-link:: https://pynapple-org.github.io/pynaviz/
+      :color: primary
+      :shadow:
 
-            Visualization (pynaviz)
+      Visualization (pynaviz)
 
-         .. button-link:: https://github.com/pynapple-org/claude-skills
-            :color: primary
-            :shadow:
+   .. button-link:: https://github.com/pynapple-org/claude-skills
+      :color: primary
+      :shadow:
 
-            Claude Code skills
+      Claude Code skills
 
 
 .. grid:: 1 1 6 6

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -37,6 +37,8 @@ import pynapple as nap
 
 To get started with pynapple, please read the [introduction](user_guide/01_introduction_to_pynapple) that introduces the minimal concepts.
 
+If you write code with an AI coding assistant, see the [Claude Code skills](external) that teach it pynapple idioms.
+
 ## Dependencies
 
 

--- a/doc/releases.md
+++ b/doc/releases.md
@@ -1,5 +1,10 @@
 # Releases
 
+### Unreleased
+
+- Added [pynapple-org/claude-skills](https://github.com/pynapple-org/claude-skills), a Claude Code skill that teaches AI coding assistants pynapple idioms. See [External Projects](external) for installation.
+
+
 ### 0.11.3 (2026-05-26)
 
 - Fixed `NeuroSuiteIO` channel indexing: `skip` and `groups` are now keyed by channel ID instead of sequential count, correcting channel ordering when IDs are non-contiguous.


### PR DESCRIPTION
This pull request adds documentation and release notes for the new [pynapple-org/claude-skills](https://github.com/pynapple-org/claude-skills) Claude Code skill, which helps AI coding assistants generate code that follows pynapple idioms. The changes inform users about the skill, provide installation instructions, and describe its purpose and scope.

**Documentation updates:**

* Added sections to `README.md`, `CONTRIBUTING.md`, `doc/external.md`, and `doc/installing.md` explaining the availability, installation, and benefits of the `pynapple` Claude Code skill, including how it teaches Claude to use pynapple-specific patterns and APIs. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R63-R77) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R30-R43) [[3]](diffhunk://#diff-dfe34bc601fb3a20029c68c0bec7bec92ccdcde29e8be43cdf992ea4f98ee4e3R69-R99) [[4]](diffhunk://#diff-1d71fbf6452c615eacc9abfd4951cbf726383a79ac5796fb8c21be4b79d49ca2R40-R41)
* Added a prominent button link to the skill in the main documentation index (`doc/index.rst`) for easy access.

**Release notes:**

* Updated `doc/releases.md` to announce the addition of the Claude Code skill and direct users to installation instructions.