### PR TITLE
Fix 620

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,7 +112,7 @@ jobs:
             --ignore-urls "https://fonts.gstatic.com,/scikit-learn\.org/,https://mkdocs-gallery.github.io,./doc/_build/html/_static/,https://www.nature.com/articles/s41593-022-01020-w,https://elifesciences.org/reviewed-preprints/85786" 
             --assume-extension 
             --check-external-hash 
-            --ignore-status-codes 403,0 
+            --ignore-status-codes 403,0,429
             --ignore-files "/.+\/html\/_static\/.+/"
           # The arguments to pass to HTMLProofer
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,7 +112,7 @@ jobs:
             --ignore-urls "https://fonts.gstatic.com,/scikit-learn\.org/,https://mkdocs-gallery.github.io,./doc/_build/html/_static/,https://www.nature.com/articles/s41593-022-01020-w,https://elifesciences.org/reviewed-preprints/85786" 
             --assume-extension 
             --check-external-hash 
-            --ignore-status-codes 403,0,429
+            --ignore-status-codes 403,0,429,503
             --ignore-files "/.+\/html\/_static\/.+/"
           # The arguments to pass to HTMLProofer
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,12 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+  workflow_dispatch:
+    inputs:
+      debug_tmate:
+        description: 'Open a tmate session if the documentation build fails'
+        type: boolean
+        default: false
 
 jobs:
   lint:
@@ -82,9 +88,13 @@ jobs:
         run: |          
           cd doc
           make html
+      # Only on a manual run with debug_tmate enabled: on pull_request this
+      # input is empty, so a failed build fails fast instead of holding the
+      # runner open until the 6h job limit.
       - name: Start tmate session for debugging
-        if: failure()
+        if: failure() && inputs.debug_tmate
         uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 15
 
       - name: Install markdown-link-check
         run: npm install -g markdown-link-check

--- a/.mlc.external.json
+++ b/.mlc.external.json
@@ -10,7 +10,7 @@
     { "pattern": "^https://www.nature.com/articles/s41593-022-01020-w" },
     { "pattern": "^https://elifesciences.org/reviewed-preprints/85786" }
   ],
-  "aliveStatusCodes": [200, 206, 302, 403, 0, 504],
+  "aliveStatusCodes": [200, 206, 302, 403, 0, 503, 504],
   "timeout": "20s",
   "retryOn429": true,
   "retryCount": 5,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -168,3 +168,6 @@ nb_execution_timeout = 60 * 15
 # Execute notebooks during the build:
 nb_execution_mode = "cache"
 nb_execution_raise_on_error = True
+# Print the failing cell's traceback, otherwise the build only reports that
+# some cell raised, which is useless in CI logs.
+nb_execution_show_tb = True

--- a/doc/user_guide/02_input_output.md
+++ b/doc/user_guide/02_input_output.md
@@ -286,9 +286,16 @@ If you have Plexon files, you can use EphysReader in the exact same way:
 
 ```{code-cell} ipython3
 :tags: [hide-cell]
-import urllib
-distantfile = "https://web.gin.g-node.org/NeuralEnsemble/ephy_testing_data/raw/master/plexon/File_plexon_3.plx"
-urllib.request.urlretrieve(distantfile, "File_plexon_3.plx")
+
+plexon_path = "File_plexon_3.plx"
+
+if plexon_path not in os.listdir("."):
+  r = requests.get(f"https://osf.io/2zvct/download", stream=True)
+  block_size = 1024*1024
+  with open(plexon_path, 'wb') as f:
+    for data in tqdm.tqdm(r.iter_content(block_size), unit='MB', unit_scale=True,
+      total=math.ceil(int(r.headers.get('content-length', 0))//block_size)):
+      f.write(data)
 ```
 
 ```{code-cell} ipython3

--- a/pynapple/io/interface_nwb.py
+++ b/pynapple/io/interface_nwb.py
@@ -197,6 +197,43 @@ def _make_tsd_tensor(obj, lazy_loading=True):
     return data
 
 
+def _extract_dynamic_table_metadata(region):
+    """Helper function to extract metadata from a DynamicTableRegion
+
+    Columns holding one array per row (e.g. the `image_mask` of a
+    `PlaneSegmentation`) are skipped based on the table schema, so they are
+    never loaded only to be dropped. They can be orders of magnitude larger
+    than the metadata itself.
+
+    Parameters
+    ----------
+    region : hdmf.common.table.DynamicTableRegion
+        The `electrodes` of an ElectricalSeries or the `rois` of a
+        RoiResponseSeries.
+
+    Returns
+    -------
+    pandas.DataFrame
+        One row per element of the region, indexed by table id.
+
+    """
+    vector_index = importlib.import_module("hdmf.common.table").VectorIndex
+
+    exclude = set()
+    for name in region.table.colnames:
+        column = region.table[name]
+        if isinstance(column, vector_index):  # ragged, e.g. pixel_mask
+            exclude.add(name)
+        elif len(column.data) and np.ndim(column.data[0]):  # e.g. image_mask
+            exclude.add(name)
+
+    return (
+        region.to_dataframe(exclude=exclude)
+        .convert_dtypes()
+        .select_dtypes(exclude="object")
+    )
+
+
 def _make_tsd_frame(obj, lazy_loading=True):
     """Helper function to make TsdFrame
 
@@ -235,11 +272,7 @@ def _make_tsd_frame(obj, lazy_loading=True):
     elif isinstance(obj, pynwb.ecephys.ElectricalSeries):
         # (channel mapping)
         try:
-            metadata = (
-                obj.electrodes.to_dataframe()
-                .convert_dtypes()
-                .select_dtypes(exclude="object")
-            )
+            metadata = _extract_dynamic_table_metadata(obj.electrodes)
             columns = metadata.index
         except Exception:
             columns = np.arange(obj.data.shape[1])
@@ -247,7 +280,8 @@ def _make_tsd_frame(obj, lazy_loading=True):
     elif isinstance(obj, pynwb.ophys.RoiResponseSeries):
         # (cell number)
         try:
-            columns = obj.rois["id"][:]
+            metadata = _extract_dynamic_table_metadata(obj.rois)
+            columns = metadata.index
         except Exception:
             columns = np.arange(obj.data.shape[1])
 
@@ -256,8 +290,12 @@ def _make_tsd_frame(obj, lazy_loading=True):
 
     if len(columns) >= d.shape[1]:  # Weird sometimes if background ID added
         columns = columns[0 : obj.data.shape[1]]
+        if len(metadata):
+            metadata = metadata.iloc[0 : obj.data.shape[1]]
     else:
+        # Columns fell back to a range index, so the metadata no longer applies
         columns = np.arange(obj.data.shape[1])
+        metadata = {}
 
     data = nap.TsdFrame(
         t=t,

--- a/pynapple/process/tuning_curves.py
+++ b/pynapple/process/tuning_curves.py
@@ -265,7 +265,10 @@ def compute_tuning_curves(
     occupancy, bin_edges = np.histogramdd(features, bins=bins, range=range)
 
     # tuning curves
-    keys = (
+    # np.asarray drops any name carried by a pandas Index (TsdFrame.columns
+    # loaded from NWB is named "id"), which xarray would otherwise use as the
+    # coordinate dimension instead of "unit".
+    keys = np.asarray(
         data.keys()
         if isinstance(data, nap.TsGroup)
         else data.columns if isinstance(data, nap.TsdFrame) else [0]
@@ -402,7 +405,8 @@ def compute_response_per_epoch(data, epochs_dict, return_pandas=False):
         raise TypeError("return_pandas should be a boolean.")
 
     # tuning curves
-    keys = (
+    # See compute_tuning_curves: np.asarray drops the pandas Index name.
+    keys = np.asarray(
         data.keys()
         if isinstance(data, nap.TsGroup)
         else data.columns if isinstance(data, nap.TsdFrame) else [0]

--- a/tests/test_nwb.py
+++ b/tests/test_nwb.py
@@ -455,6 +455,127 @@ def test_add_Ophys():
         pass  # some issues with pynwb version
 
 
+def _plane_segmentation(n_rois, name, ragged=False):
+    """Build a PlaneSegmentation with scalar columns next to an image_mask."""
+    from pynwb.ophys import PlaneSegmentation
+    from pynwb.testing.mock.ophys import mock_ImagingPlane
+
+    plane_segmentation = PlaneSegmentation(
+        description="plane segmentation",
+        imaging_plane=mock_ImagingPlane(),
+        name=name,
+    )
+    plane_segmentation.add_column(name="cell_id", description="cell id")
+    plane_segmentation.add_column(name="depth_um", description="depth")
+    if ragged:
+        plane_segmentation.add_column(name="ragged", description="ragged", index=True)
+
+    for i in range(n_rois):
+        extra = {"ragged": [1] * (i + 1)} if ragged else {}
+        plane_segmentation.add_roi(
+            image_mask=np.zeros((4, 4)), cell_id=i, depth_um=float(10 * i), **extra
+        )
+    return plane_segmentation
+
+
+def _roi_response_series(plane_segmentation, n_columns, n_rois=None, name="RRS"):
+    """RoiResponseSeries over `n_rois` rows of `plane_segmentation`."""
+    from hdmf.common.table import DynamicTableRegion
+    from pynwb.ophys import RoiResponseSeries
+
+    n_rois = len(plane_segmentation.id) if n_rois is None else n_rois
+    return RoiResponseSeries(
+        name=name,
+        data=np.ones((30, n_columns)),
+        unit="n.a.",
+        rate=1.0,
+        rois=DynamicTableRegion(
+            name="rois",
+            description="rois",
+            table=plane_segmentation,
+            data=list(range(n_rois)),
+        ),
+    )
+
+
+def test_add_Ophys_roi_metadata():
+    """RoiResponseSeries should carry the PlaneSegmentation columns as metadata.
+
+    See https://github.com/pynapple-org/pynapple/issues/620
+    """
+    pytest.importorskip("pynwb.testing.mock.ophys")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+
+        name_generator_registry.clear()
+        plane_segmentation = _plane_segmentation(3, "PlaneSegmentation")
+        series = _roi_response_series(plane_segmentation, n_columns=3)
+        data = nap.io.interface_nwb._make_tsd_frame(series)
+
+        assert isinstance(data, nap.TsdFrame)
+        # the scalar columns are attached, the image mask is not
+        assert list(data.metadata.columns) == ["cell_id", "depth_um"]
+        np.testing.assert_array_equal(data.metadata["cell_id"].values, [0, 1, 2])
+        np.testing.assert_array_equal(
+            data.metadata["depth_um"].values, [0.0, 10.0, 20.0]
+        )
+        # columns still track the roi ids
+        np.testing.assert_array_equal(data.columns.values, series.rois["id"][:])
+
+
+def test_add_Ophys_roi_metadata_excludes_ragged():
+    """Ragged columns (e.g. pixel_mask) are skipped like image masks."""
+    pytest.importorskip("pynwb.testing.mock.ophys")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+
+        name_generator_registry.clear()
+        plane_segmentation = _plane_segmentation(3, "PlaneSegmentation", ragged=True)
+        series = _roi_response_series(plane_segmentation, n_columns=3)
+        data = nap.io.interface_nwb._make_tsd_frame(series)
+
+        assert list(data.metadata.columns) == ["cell_id", "depth_um"]
+
+
+def test_add_Ophys_roi_metadata_extra_roi():
+    """Metadata is truncated with the columns when the region has extra rois."""
+    pytest.importorskip("pynwb.testing.mock.ophys")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+
+        name_generator_registry.clear()
+        plane_segmentation = _plane_segmentation(4, "PlaneSegmentation")
+        # 4 rois in the region, but only 3 columns of data
+        series = _roi_response_series(plane_segmentation, n_columns=3, n_rois=4)
+        data = nap.io.interface_nwb._make_tsd_frame(series)
+
+        assert data.shape == (30, 3)
+        assert len(data.metadata) == 3
+        np.testing.assert_array_equal(data.metadata["cell_id"].values, [0, 1, 2])
+
+
+def test_add_Ophys_roi_metadata_only_image_mask():
+    """A PlaneSegmentation without scalar columns yields empty metadata."""
+    pytest.importorskip("pynwb.testing.mock.ophys")
+    from pynwb.testing.mock.ophys import mock_PlaneSegmentation, mock_RoiResponseSeries
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+
+        name_generator_registry.clear()
+        series = mock_RoiResponseSeries(
+            plane_segmentation=mock_PlaneSegmentation(n_rois=5)
+        )
+        data = nap.io.interface_nwb._make_tsd_frame(series)
+
+        assert isinstance(data, nap.TsdFrame)
+        assert len(data.metadata.columns) == 0
+        np.testing.assert_array_equal(data.columns.values, series.rois["id"][:])
+
+
 def test_add_TimeIntervals():
     # 1 epochset
     nwbfile = mock_NWBFile()

--- a/tests/test_tuning_curves.py
+++ b/tests/test_tuning_curves.py
@@ -905,6 +905,30 @@ def test_compute_tuning_curves(data, features, kwargs, expectation):
                     )
 
 
+def test_compute_tuning_curves_named_columns():
+    """TsdFrame columns loaded from NWB carry the name "id", which xarray would
+    use as the coordinate dimension instead of "unit". See issue #624."""
+    t = np.arange(0, 100, 0.1)
+    data = nap.TsdFrame(
+        t=t,
+        d=np.random.rand(len(t), 3),
+        columns=pd.Index([0, 1, 2], name="id"),
+    )
+    features = nap.Tsd(t=t, d=t % 10)
+
+    tcs = nap.compute_tuning_curves(data, features, bins=10)
+    assert tcs.dims == ("unit", "0")
+    assert tcs.coords["unit"].dims == ("unit",)
+
+    epochs_dict = {
+        "ep0": nap.IntervalSet(start=0, end=50),
+        "ep1": nap.IntervalSet(start=50, end=100),
+    }
+    responses = nap.compute_response_per_epoch(data, epochs_dict)
+    assert responses.dims == ("unit", "epochs")
+    assert responses.coords["unit"].dims == ("unit",)
+
+
 # ------------------------------------------------------------------------------------
 # DISCRETE TUNING CURVE TESTS
 # ------------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request improves how metadata is extracted and attached from NWB `DynamicTableRegion` objects (such as ROI/cell metadata in ophys data), ensuring that only relevant scalar columns are included and large or ragged array columns are excluded. It also adds comprehensive tests to verify this behavior, especially for edge cases.

**Enhancements to NWB metadata extraction and handling:**

* Added `_extract_dynamic_table_metadata`, a helper function that extracts only scalar (non-object, non-ragged) columns from a `DynamicTableRegion`, skipping large columns like `image_mask` or ragged columns (e.g., `pixel_mask`).
* Updated `_make_tsd_frame` to use `_extract_dynamic_table_metadata` for both `ElectricalSeries` and `RoiResponseSeries`, ensuring only appropriate metadata is attached to the resulting `TsdFrame`.
* Improved handling when the number of metadata rows does not match the data columns: metadata is truncated or cleared as appropriate to prevent misalignment.

**Expanded test coverage for ophys ROI metadata extraction:**

* Added several test cases to `tests/test_nwb.py`:
  - Verifies that only scalar columns are included as metadata and image/ragged columns are excluded.
  - Checks correct metadata truncation when there are extra ROIs.
  - Ensures empty metadata is handled gracefully when only image masks are present.