### PR TITLE
Introduce codespell: config, CI, tox env, and fix existing typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -4,9 +4,9 @@ name: Codespell
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 permissions:
   contents: read

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Codespell
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Special thanks to Francesco P. Battaglia
 *neuroseries* (<https://github.com/NeuroNetMem/neuroseries>) packages,
 the latter constituting the core of *pynapple*.
 
-This package was developped by Guillaume Viejo
+This package was developed by Guillaume Viejo
 (<https://github.com/gviejo>) and other members of the Peyrache Lab.
 
 <!-- Logo: Sofia Skromne Carrasco, 2021. -->

--- a/doc/pynajax.md
+++ b/doc/pynajax.md
@@ -11,7 +11,7 @@
 Multiple python packages exist for high-performance computing. Internally, pynapple makes extensive use of [numba](https://numba.pydata.org/) for accelerating some functions. Numba is a stable package that provide speed gains with minimal installation issues when running on CPUs.
 
 Another high-performance toolbox for numerical analysis is 
-[jax](https://jax.readthedocs.io/en/latest/index.html). In addition to accelerating python code on CPUs, GPUs, and TPUs, it provides a special representation of arrays using the [jax Array object](https://jax.readthedocs.io/en/latest/jax-101/01-jax-basics.html). Unfortunately, jax Array is incompatible with Numba. To solve this issue, we developped [pynajax](https://github.com/pynapple-org/pynajax).
+[jax](https://jax.readthedocs.io/en/latest/index.html). In addition to accelerating python code on CPUs, GPUs, and TPUs, it provides a special representation of arrays using the [jax Array object](https://jax.readthedocs.io/en/latest/jax-101/01-jax-basics.html). Unfortunately, jax Array is incompatible with Numba. To solve this issue, we developed [pynajax](https://github.com/pynapple-org/pynajax).
 
 Pynajax is an accelerated backend for pynapple built on top on jax. It offers a fast acceleration for some pynapple functions using CPU or GPU. Here is a minimal example on how to use pynajax:
 

--- a/doc/releases.md
+++ b/doc/releases.md
@@ -297,4 +297,4 @@
 ### 0.1.1 (2021-10-25)
 
 -   First release on PyPI.
-- 	Firt minimal version
+- 	First minimal version

--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -61,7 +61,7 @@ Power spectral density <user_guide/10_power_spectral_density>
 
 ```{toctree}
 :maxdepth: 2
-Wavelet decomposion <user_guide/11_wavelets>
+Wavelet decomposition <user_guide/11_wavelets>
 ```
 
 ```{toctree}

--- a/doc/user_guide/01_introduction_to_pynapple.md
+++ b/doc/user_guide/01_introduction_to_pynapple.md
@@ -117,7 +117,7 @@ print(ts)
 ### [`nap.TsGroup`](pynapple.TsGroup): group of timestamps
 
 
-[`TsGroup`](pynapple.TsGroup) is a dictionnary that stores multiple time series with different time stamps (.i.e. a group of neurons with different spike times from one session). The first argument `data` can be a dictionnary of `Ts`, `Tsd` or numpy 1d array.
+[`TsGroup`](pynapple.TsGroup) is a dictionary that stores multiple time series with different time stamps (.i.e. a group of neurons with different spike times from one session). The first argument `data` can be a dictionary of `Ts`, `Tsd` or numpy 1d array.
 
 
 ```{code-cell} ipython3
@@ -140,7 +140,7 @@ Interaction between pynapple objects
 ### Time support : attribute of time series
 
 
-A key feature of how pynapple manipulates time series is an inherent time support object defined for `Ts`, `Tsd`, `TsdFrame` and `TsGroup` objects. The time support object is defined as an `IntervalSet` that provides the time serie with a context. For example, the restrict operation will automatically update the time support object for the new time series. Ideally, the time support object should be defined for all time series when instantiating them. If no time series is given, the time support is inferred from the start and end of the time series.
+A key feature of how pynapple manipulates time series is an inherent time support object defined for `Ts`, `Tsd`, `TsdFrame` and `TsGroup` objects. The time support object is defined as an `IntervalSet` that provides the time series with a context. For example, the restrict operation will automatically update the time support object for the new time series. Ideally, the time support object should be defined for all time series when instantiating them. If no time series is given, the time support is inferred from the start and end of the time series.
 
 In this example, a `Tsd` is instantiated with and without a time support of intervals 0 to 5 seconds. Notice how the shape of the `Tsd` varies.
 
@@ -412,7 +412,7 @@ my.nwb
 ┕━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━┙
 ```
 
-The returned object behaves like a dictionnary. The first column indicates the keys. The second column indicate the object type.
+The returned object behaves like a dictionary. The first column indicates the keys. The second column indicate the object type.
 
 ```
 print(nwb['units'])
@@ -438,7 +438,7 @@ This module analyses discrete events, specifically correlograms (for example by 
 
 **[Bayesian decoding](07_decoding)**
 
-The decoding module perfoms bayesian decoding given a set of tuning curves and a `TsGroup`.
+The decoding module performs bayesian decoding given a set of tuning curves and a `TsGroup`.
 
 **[Filtering](12_filtering)**
 

--- a/doc/user_guide/02_input_output.md
+++ b/doc/user_guide/02_input_output.md
@@ -510,7 +510,7 @@ print(project["sub-A2929"]["A2929-200711"]["pynapplenwb"]["A2929-200711"])
 A good practice for sharing datasets is to write as many 
 metainformation as possible. Following 
 [BIDS](https://bids-standard.github.io/bids-starter-kit/index.html) 
-specifications, any data files should be accompagned by a JSON sidecar file.
+specifications, any data files should be accompanied by a JSON sidecar file.
 
 This is possible using the `Folder` class of pynapple with the argument `description`.
 

--- a/doc/user_guide/03_interacting_with_numpy.md
+++ b/doc/user_guide/03_interacting_with_numpy.md
@@ -202,7 +202,7 @@ print(np.concatenate((tsdframe, tsdframe), 1))
 ```
 
 Splitting
---------
+---------
 Array split functions are also implemented
 
 

--- a/doc/user_guide/03_interacting_with_numpy.md
+++ b/doc/user_guide/03_interacting_with_numpy.md
@@ -23,7 +23,7 @@ import pynapple as nap
 import pandas as pd
 ```
 
-Multiple time series object are avaible depending on the shape of the data.
+Multiple time series object are available depending on the shape of the data.
 
 - `TsdTensor` : for data with of more than 2 dimensions, typically movies.
 - `TsdFrame` : for column-based data. It can be easily converted to a pandas.DataFrame. Columns can be labelled and selected similar to pandas.
@@ -69,7 +69,7 @@ print(tsdframe.as_dataframe())
 
 Attributes
 ----------
-The numpy array is accesible with the attributes `.values`, `.d` and functions [`as_array()`](pynapple.Tsd.as_array), [`to_numpy()`](pynapple.Tsd.to_numpy).
+The numpy array is accessible with the attributes `.values`, `.d` and functions [`as_array()`](pynapple.Tsd.as_array), [`to_numpy()`](pynapple.Tsd.to_numpy).
 The time index array is a `TsIndex` object accessible with `.index` or `.t`.
 `.shape` and `.ndim` are also accessible.
 
@@ -201,7 +201,7 @@ tsdframe = nap.TsdFrame(t=np.arange(5), d=np.random.randn(5, 3))
 print(np.concatenate((tsdframe, tsdframe), 1))
 ```
 
-Spliting
+Splitting
 --------
 Array split functions are also implemented
 

--- a/doc/user_guide/03_metadata.md
+++ b/doc/user_guide/03_metadata.md
@@ -186,7 +186,7 @@ Single metadata columns (or lists of columns) can be retrieved using the [`get_i
 print(tsgroup.get_info("region"))
 ```
 
-Similarly, metadata can be accessed using key indexing (i.e. square brakets)
+Similarly, metadata can be accessed using key indexing (i.e. square brackets)
 
 ```{code-cell} ipython3
 print(tsgroup["region"])

--- a/doc/user_guide/03_metadata.md
+++ b/doc/user_guide/03_metadata.md
@@ -158,7 +158,7 @@ print(tsgroup)
 ```
 
 ### Using attribute assignment
-If the metadata name is unique from other class attributes and methods, and it is formatted properly (i.e. only alpha-numeric characters and underscores), it can be set as an attribute (i.e. using a `.` followed by the metadata name).
+If the metadata name is unique from other class attributes and methods, and it is formatted properly (i.e. only alphanumeric characters and underscores), it can be set as an attribute (i.e. using a `.` followed by the metadata name).
 
 ```{code-cell} ipython3
 tsgroup.label=["MUA", "good", "good", "good"]

--- a/doc/user_guide/05_correlograms_isi.md
+++ b/doc/user_guide/05_correlograms_isi.md
@@ -43,7 +43,7 @@ print(ts_group)
 
 We can compute their autocorrelograms meaning the number of spikes of a neuron observed in a time windows centered around its own spikes.
 For this we can use the function [`compute_autocorrelogram`](pynapple.process.correlograms.compute_autocorrelogram).
-We need to specifiy the `binsize` and `windowsize` to bin the spike train.
+We need to specify the `binsize` and `windowsize` to bin the spike train.
 
 ```{code-cell} ipython3
 autocorrs = nap.compute_autocorrelogram(

--- a/pynapple/core/_jitted_functions.py
+++ b/pynapple/core/_jitted_functions.py
@@ -579,7 +579,7 @@ def jitunion(start1, end1, start2, end2):
                 )  # end of interval is whichever occurs last
 
                 if end1[i] < end2[j]:
-                    i += 1  # incremet set 1 index if it ends first
+                    i += 1  # increment set 1 index if it ends first
                 else:
                     j += 1  # increment set 2 index if it ends first
 

--- a/pynapple/core/base_class.py
+++ b/pynapple/core/base_class.py
@@ -231,11 +231,11 @@ class _Base(abc.ABC):
 
     def count(self, bin_size=None, ep=None, time_units="s", dtype=None):
         """
-        Count occurences of events within bin_size or within a set of bins defined as an IntervalSet.
+        Count occurrences of events within bin_size or within a set of bins defined as an IntervalSet.
         You can call this function in multiple ways :
 
         1. *tsd.count(bin_size=1, time_units = 'ms')*
-        -> Count occurence of events within a 1 ms bin defined on the time support of the object.
+        -> Count occurrence of events within a 1 ms bin defined on the time support of the object.
 
         2. *tsd.count(1, ep=my_epochs)*
         -> Count occurent of events within a 1 second bin defined on the IntervalSet my_epochs.

--- a/pynapple/core/interval_set.py
+++ b/pynapple/core/interval_set.py
@@ -775,7 +775,7 @@ class IntervalSet(NDArrayOperatorsMixin, _MetadataMixin):
         threshold : numeric
             Time threshold for "short" intervals
         time_units : None, optional
-            The time units for the treshold ('us', 'ms', 's' [default])
+            The time units for the threshold ('us', 'ms', 's' [default])
 
         Returns
         -------
@@ -796,7 +796,7 @@ class IntervalSet(NDArrayOperatorsMixin, _MetadataMixin):
         threshold : numeric
             Time threshold for "long" intervals
         time_units : None, optional
-            The time units for the treshold ('us', 'ms', 's' [default])
+            The time units for the threshold ('us', 'ms', 's' [default])
 
         Returns
         -------

--- a/pynapple/core/interval_set.py
+++ b/pynapple/core/interval_set.py
@@ -962,7 +962,7 @@ class IntervalSet(NDArrayOperatorsMixin, _MetadataMixin):
     def split(self, interval_size, time_units="s"):
         """Split `IntervalSet` to a new `IntervalSet` with each interval being of size `interval_size`.
 
-        Used mostly for chunking very large dataset or looping throught multiple epoch of same duration.
+        Used mostly for chunking very large dataset or looping through multiple epoch of same duration.
 
         This function skips the epochs that are shorter than `interval_size`.
 

--- a/pynapple/core/metadata_class.py
+++ b/pynapple/core/metadata_class.py
@@ -251,7 +251,7 @@ class _MetadataMixin:
                 # metadata is a dictionary-like object
                 if (
                     hasattr(metadata, "index")
-                    # exlude length 1 objects in case of pandas.Series
+                    # exclude length 1 objects in case of pandas.Series
                     and (len(self.metadata_index) > 1)
                     and not np.all(self.metadata_index == metadata.index)
                 ):

--- a/pynapple/core/metadata_class.py
+++ b/pynapple/core/metadata_class.py
@@ -636,7 +636,7 @@ class _Metadata(UserDict):
     @property
     def dtypes(self):
         """
-        Dictonary of data types for each metadata column.
+        Dictionary of data types for each metadata column.
         """
         return {k: self.data[k].dtype for k in self.columns}
 

--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -562,7 +562,7 @@ class _BaseTsd(_ReconstructMixin, _Base, NDArrayOperatorsMixin, abc.ABC):
             raise IOError("Array should be 1 or 2 dimension.")
 
         if trim not in ["both", "left", "right"]:
-            raise IOError("Unknow argument. trim should be 'both', 'left' or 'right'.")
+            raise IOError("Unknown argument. trim should be 'both', 'left' or 'right'.")
 
         time_array = self.index.values
         data_array = self.values
@@ -2511,7 +2511,7 @@ class TsdFrame(_BaseTsd, _MetadataMixin):
         xpos        10   20    30
         dtype: float64, shape: (5, 3)
 
-        To add metadata with a keyword arument (pd.Series, numpy.ndarray, list or tuple):
+        To add metadata with a keyword argument (pd.Series, numpy.ndarray, list or tuple):
 
         >>> ypos = pd.Series(index=tsdframe.columns, data = [10, 10, 10])
         >>> tsdframe.set_info(ypos=ypos)

--- a/pynapple/core/ts_group.py
+++ b/pynapple/core/ts_group.py
@@ -392,7 +392,7 @@ class TsGroup(UserDict, _MetadataMixin):
             if len(key) != self.__len__():
                 raise IndexError(
                     "Boolean index length must be equal to the number of Ts in the group! "
-                    f"The number of Ts is {self.__len__()}, but the bolean array"
+                    f"The number of Ts is {self.__len__()}, but the boolean array"
                     f"has length {len(key)} instead!"
                 )
             key = self.index[key]
@@ -702,11 +702,11 @@ class TsGroup(UserDict, _MetadataMixin):
     @add_or_convert_metadata
     def count(self, bin_size=None, ep=None, time_units="s", dtype=None):
         """
-        Count occurences of events within bin_size or within a set of bins defined as an IntervalSet.
+        Count occurrences of events within bin_size or within a set of bins defined as an IntervalSet.
         You can call this function in multiple ways :
 
         1. *tsgroup.count(bin_size=1, time_units = 'ms')*
-        -> Count occurence of events within a 1 ms bin defined on the time support of the object.
+        -> Count occurrence of events within a 1 ms bin defined on the time support of the object.
 
         2. *tsgroup.count(1, ep=my_epochs)*
         -> Count occurent of events within a 1 second bin defined on the IntervalSet my_epochs.
@@ -1171,7 +1171,7 @@ class TsGroup(UserDict, _MetadataMixin):
         Raises
         ------
         RuntimeError
-            Raise eror is operation is not recognized.
+            Raise error is operation is not recognized.
 
         Examples
         --------
@@ -1182,7 +1182,7 @@ class TsGroup(UserDict, _MetadataMixin):
         ...        2: nap.Ts(t=np.arange(0, 300, 0.25), time_units='s')}
         >>> tsgroup = nap.TsGroup(tmp)
 
-        This exemple shows how to get a new TsGroup with all elements for which the rate is above 1.
+        This example shows how to get a new TsGroup with all elements for which the rate is above 1.
 
         >>> newtsgroup = tsgroup.getby_threshold('rate', 1, op='>')
         >>> newtsgroup
@@ -1233,7 +1233,7 @@ class TsGroup(UserDict, _MetadataMixin):
         ...        2: nap.Ts(t=np.arange(0, 300, 0.25), time_units='s')}
         >>> tsgroup = nap.TsGroup(tmp, metadata={"alpha": np.arange(3)})
 
-        This exemple shows how to bin the TsGroup according to one metainfo key.
+        This example shows how to bin the TsGroup according to one metainfo key.
 
         >>> newtsgroup, bincenter = tsgroup.getby_intervals('alpha', [0, 1, 2])
         >>> newtsgroup[0]
@@ -1284,7 +1284,7 @@ class TsGroup(UserDict, _MetadataMixin):
         ...        2: nap.Ts(t=np.arange(0, 300, 0.25), time_units='s')}
         >>> tsgroup = nap.TsGroup(tmp, metadata={"group": [0, 1, 1]})
 
-        This exemple shows how to group the TsGroup according to one metainfo key.
+        This example shows how to group the TsGroup according to one metainfo key.
 
         >>> newtsgroup = tsgroup.getby_category('group')
         >>> newtsgroup[0]

--- a/pynapple/io/folder.py
+++ b/pynapple/io/folder.py
@@ -73,7 +73,7 @@ def _walk_folder(tree, folder):
 
 class Folder(UserDict):
     """
-    Dictionnary like object to walk and loop through nested folders.
+    Dictionary like object to walk and loop through nested folders.
     Handles files and sub-folders discovery
 
     Attributes

--- a/pynapple/io/interface_npz.py
+++ b/pynapple/io/interface_npz.py
@@ -65,7 +65,7 @@ class NPZFile(object):
         self.file = np.load(self.path, allow_pickle=True)
         type_ = ""
 
-        # First check if type is explicitely defined in the file:
+        # First check if type is explicitly defined in the file:
         try:
             type_ = self.file["type"][0]
             assert type_ in EXPECTED_ENTRIES.keys()

--- a/pynapple/io/loader.py
+++ b/pynapple/io/loader.py
@@ -106,7 +106,7 @@ class BaseLoader(object):
         if len(position):
             position = pd.DataFrame.from_dict(position)
 
-            # retrieveing time support position if in epochs
+            # retrieving time support position if in epochs
             if "position_time_support" in nwbfile.intervals.keys():
                 epochs = nwbfile.intervals["position_time_support"].to_dataframe()
                 time_support = nap.IntervalSet(

--- a/pynapple/io/misc.py
+++ b/pynapple/io/misc.py
@@ -191,7 +191,7 @@ def load_binary_file(
     Deleted Parameters
     ------------------
     extension : str, optional
-        The file extention (.eeg, .dat, .lfp). Make sure the frequency match
+        The file extension (.eeg, .dat, .lfp). Make sure the frequency match
 
     """
     # Need to check if a xml file exists

--- a/pynapple/io/misc.py
+++ b/pynapple/io/misc.py
@@ -70,7 +70,7 @@ def load_file(path, lazy_loading=None):
 
 def load_folder(path):
     """Load folder containing files or other folder.
-    Pynapple will walk throught the subfolders to detect compatible npz files
+    Pynapple will walk through the subfolders to detect compatible npz files
     or nwb files.
 
     Parameters

--- a/pynapple/io/neurosuite.py
+++ b/pynapple/io/neurosuite.py
@@ -100,7 +100,7 @@ class NeuroSuite(BaseLoader):
         channel : int or list of int, optional
             The channel(s) to load. If None return a memory map of the dat file to avoid memory error
         extension : str, optional
-            The file extenstion (.eeg, .dat, .lfp). Make sure the frequency match
+            The file extension (.eeg, .dat, .lfp). Make sure the frequency match
         frequency : float, optional
             Default 1250 Hz for the eeg file
         precision : str, optional

--- a/pynapple/io/phy.py
+++ b/pynapple/io/phy.py
@@ -93,7 +93,7 @@ class Phy(BaseLoader):
         channel : int or list of int, optional
             The channel(s) to load. If None return a memory map of the dat file to avoid memory error
         extension : str, optional
-            The file extenstion (.eeg, .dat, .lfp). Make sure the frequency match
+            The file extension (.eeg, .dat, .lfp). Make sure the frequency match
         frequency : float, optional
             Default 1250 Hz for the eeg file
         precision : str, optional

--- a/pynapple/process/perievent.py
+++ b/pynapple/process/perievent.py
@@ -24,7 +24,7 @@ def compute_event_triggered_average(
     Notes
     -----
     If `C` is the event count matrix and ``feature`` is a `Tsd`, then the function computes
-    the Hankel matrix H from ``window=(-t1,+t2)`` by offseting the `Tsd`.
+    the Hankel matrix H from ``window=(-t1,+t2)`` by offsetting the `Tsd`.
     The ETA is then defined as the dot product between `H` and `C` divided by the number of events.
 
     Parameters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,4 +160,7 @@ skip = '.git*,*.pdf,*.svg,versioneer.py,doc/_build,*.lock'
 check-hidden = true
 # Ignore embedded base64 images in notebooks
 ignore-regex = '^\s*"image/\S+": ".*'
-# ignore-words-list = ''
+# adn: Anterior Dorsal nucleus (neuroanatomy, see doc/examples/tutorial_HD_dataset.md)
+# countin: variable name in _jitted_functions.py meaning "count in"
+# nin: numpy ufunc attribute (ufunc.nin = number of inputs)
+ignore-words-list = 'adn,countin,nin'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,3 +153,11 @@ omit = [
 ignore = ["E203", "E501", "W293", "E231", "W503", "C901", "W291", "E266"]
 max-complexity = 10
 exclude = ["doc", "__init__.py", "tests"]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*,*.pdf,*.svg,versioneer.py,doc/_build,*.lock'
+check-hidden = true
+# Ignore embedded base64 images in notebooks
+ignore-regex = '^\s*"image/\S+": ".*'
+# ignore-words-list = ''

--- a/tests/test_jitted.py
+++ b/tests/test_jitted.py
@@ -45,7 +45,7 @@ def get_example_isets(n=100):
 
 def restrict(ep, tsd):
     bins = ep.values.ravel()
-    # Because yes there is no funtion with both bounds closed as an option
+    # Because yes there is no function with both bounds closed as an option
     ix = np.array(
         pd.cut(tsd.index, bins, labels=np.arange(len(bins) - 1, dtype=np.float64))
     )

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -453,7 +453,7 @@ class TestIntervalSetMetadata:
                 # key should match metadata
                 does_not_raise(),
             ),
-            # existing metdata
+            # existing metadata
             (
                 "label",
                 # no warning with set_info
@@ -608,7 +608,7 @@ class TestTsdFrameMetadata:
                 # key should match metadata
                 does_not_raise(),
             ),
-            # existing metdata
+            # existing metadata
             (
                 "l1",
                 # attribute exists
@@ -751,7 +751,7 @@ class TestTsGroupMetadata:
                 # get key is metadata
                 does_not_raise(),
             ),
-            # existing metdata
+            # existing metadata
             (
                 "label",
                 # no warning with set_info
@@ -2041,12 +2041,12 @@ class TestMetadataDict:
             if isinstance(loc, tuple):
                 np.testing.assert_array_equal(meta.loc[loc].index, index[loc[0]])
                 if isinstance(loc[1], str):
-                    # tuple that retuns some value
+                    # tuple that returns some value
                     np.testing.assert_array_equal(
                         meta.loc[loc][loc[1]], data[loc[1]][loc[0]]
                     )
                 else:
-                    # tuple that retuns a _Metadata object
+                    # tuple that returns a _Metadata object
                     for key in loc[1]:
                         np.testing.assert_array_equal(
                             meta.loc[loc][key], data[key][loc[0]]
@@ -2200,7 +2200,7 @@ class TestMetadataDict:
     )
     def test_metadata_dict_drop(self, index, data, dropped):
         """
-        Test dropping metdata from the metadata dictionary directly
+        Test dropping metadata from the metadata dictionary directly
         """
         meta = _Metadata(index, data)
         meta["info"] = [2] * len(index)

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -641,7 +641,7 @@ class TestTimeSeriesGeneral:
                 tsd.convolve(np.ones(3), trim="a")
             assert (
                 str(e_info.value)
-                == "Unknow argument. trim should be 'both', 'left' or 'right'."
+                == "Unknown argument. trim should be 'both', 'left' or 'right'."
             )
 
             with pytest.raises(IOError) as e_info:

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,12 @@ commands =
     coverage run --source=pynapple --branch -m pytest tests/
     coverage report -m
 
+[testenv:codespell]
+description = Check spelling with codespell (config in pyproject.toml)
+skip_install = true
+deps = codespell[toml]
+commands = codespell {posargs}
+
 [gh-actions]
 python =
     3.10: py310


### PR DESCRIPTION
Introduces [codespell](https://github.com/codespell-project/codespell)
spell-checking to pynapple: configuration, CI, and a first pass of
typo fixes.

I have introduced codespell to 100+ projects with mostly positive
feedback (see [improveit-dashboard][idb] for context on my past PRs).
The CI job has `permissions` limited to `read`, so it can't push or
comment.

[idb]: https://github.com/yarikoptic/improveit-dashboard/blob/master/READMEs/yarikoptic.md

Prior art: 
- initial attempt at #151 which rotted and was closed
- by now there were 13+ historical commits touching "typo" / "spell"
in this repo (e.g. `d2f3b7be fix typo`, `86ca8121 Fixing a few typos`),
so automated spell-checking should pull its weight.

<details>
<summary><b>Details</b> (config, whitelist rationale, and how the typos were fixed)</summary>

### Configuration

- `[tool.codespell]` in `pyproject.toml`: `skip`, `check-hidden`,
  and an `ignore-regex` to skip base64 image payloads in notebooks.
- `.github/workflows/codespell.yml`: runs on push and PR to `main`
  and `dev` (per `CONTRIBUTING.md`, PRs target `dev`).
- `tox -e codespell` env, using the same config from
  `pyproject.toml`.

### Domain-specific whitelist (`ignore-words-list`)

Each entry has an in-config comment explaining the choice:

- `adn` — Anterior Dorsal nucleus (neuroanatomy, used throughout
  `doc/examples/tutorial_HD_dataset.md`).
- `countin` — variable name in
  `pynapple/core/_jitted_functions.py`, semantically "count in", not
  "counting".
- `nin` — numpy ufunc attribute (`ufunc.nin` = number of inputs);
  appears in `tests/test_numpy_compatibility.py`.

### Ambiguous typos (fixed manually, in a dedicated commit)

codespell -w skips these because each has multiple candidate
completions:

- `throught` → `through` (2 sites — `pynapple/io/misc.py` docstring
  and `pynapple/core/interval_set.py:IntervalSet.split` docstring).
- `exlude` → `exclude` (code comment in `metadata_class.py`).
- `Firt` → `First` in the changelog (`doc/releases.md`).
- `brakets` → `brackets` (`doc/user_guide/03_metadata.md`).

### Non-ambiguous typos (fixed by `codespell -w`)

Wrapped in `datalad run` so the exact command is recorded in the
commit metadata and is `datalad rerun`-able. Common patterns fixed:
`developped` → `developed`, `occurences` → `occurrences`,
`dictionnary`/`Dictonary` → `dictionary`/`Dictionary`,
`Unknow` → `Unknown`, `exemple` → `example`,
`extenstion`/`extention` → `extension`, `metdata` → `metadata`,
`retuns` → `returns`, `treshold` → `threshold`,
`decomposion` → `decomposition`, `serie` (as in "time serie") → `series`,
plus one-off fixes like `bolean`, `eror`, `arument`, `perfoms`,
`accompagned`, `avaible`, `accesible`, `Spliting`, `alpha-numeric`,
`specifiy`, `offseting`, `funtion`, `retrieveing`, `explicitely`,
`incremet`.

### Formatting fixup

`codespell -w` turned "Spliting" (8 chars) into "Splitting" (9 chars)
in `doc/user_guide/03_interacting_with_numpy.md` but left the setext
underline at 8 dashes. Added one dash to keep the section rule
consistent with siblings.

</details>

## Testing

- [x] `codespell` passes cleanly (`uvx codespell` returns 0 with the
  config in this PR).
- [x] Only single-suggestion typos were fed to `codespell -w`;
  multi-suggestion candidates were resolved by hand from context.
- [x] Full diff reviewed for false positives (regex patterns,
  variable names, domain terminology) — none found.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) and love to typos free code
