### PR TITLE
Fix 626

### DIFF
--- a/pynapple/core/time_series.py
+++ b/pynapple/core/time_series.py
@@ -533,6 +533,10 @@ class _BaseTsd(_ReconstructMixin, _Base, NDArrayOperatorsMixin, abc.ABC):
 
         The only mode supported is full. The returned object is trimmed to match the size of the original object. The parameter trim controls which side the trimming operates. Default is 'both'.
 
+        The signal is zero-padded outside of each epoch. A warning is raised if the kernel is
+        longer than the number of samples of one of the epochs as the output is then entirely
+        determined by the padding.
+
         See the numpy documentation here : https://numpy.org/doc/stable/reference/generated/numpy.convolve.html
 
         Parameters
@@ -549,6 +553,14 @@ class _BaseTsd(_ReconstructMixin, _Base, NDArrayOperatorsMixin, abc.ABC):
         -------
         Tsd, TsdFrame or TsdTensor
             The convolved time series
+        """
+        return self._convolve_kernel(array, ep=ep, trim=trim, stacklevel=3)
+
+    def _convolve_kernel(self, array, ep=None, trim="both", stacklevel=3):
+        """Implementation of `convolve`.
+
+        `stacklevel` is passed to the warning raised when the kernel is longer than an epoch,
+        so that it points to the caller of the public method (`convolve` or `smooth`).
         """
         if not is_array_like(array):
             raise IOError(
@@ -579,6 +591,21 @@ class _BaseTsd(_ReconstructMixin, _Base, NDArrayOperatorsMixin, abc.ABC):
             idx = _restrict(time_array, starts, ends)
             time_array = time_array[idx]
             data_array = data_array[idx]
+
+        n_samples = np.searchsorted(time_array, ends, side="right") - np.searchsorted(
+            time_array, starts
+        )
+        too_short = n_samples < len(array)
+        if np.any(too_short):
+            warnings.warn(
+                f"Kernel size ({len(array)} samples) is larger than the number of samples in "
+                f"{np.sum(too_short)} out of {len(n_samples)} epochs (shortest epoch has "
+                f"{n_samples.min()} samples). The signal is zero-padded outside each epoch, so "
+                "every point of the output in those epochs is contaminated by the padding and "
+                "artifacts are expected. Consider decreasing the kernel/window size.",
+                UserWarning,
+                stacklevel=stacklevel,
+            )
 
         new_data_array = _convolve(time_array, data_array, starts, ends, array, trim)
 
@@ -618,6 +645,10 @@ class _BaseTsd(_ReconstructMixin, _Base, NDArrayOperatorsMixin, abc.ABC):
             >>> tsd.convolve(window)  # doctest: +SKIP
 
         It is generally a good idea to visualize the kernel before applying any convolution.
+
+        The signal is zero-padded outside of each epoch. A warning is raised if the gaussian
+        window is longer than the number of samples of one of the epochs. `windowsize` and
+        `size_factor` can be decreased to reduce the size of the window.
 
         See the scipy documentation for the [gaussian window](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.gaussian.html)
 
@@ -673,7 +704,7 @@ class _BaseTsd(_ReconstructMixin, _Base, NDArrayOperatorsMixin, abc.ABC):
         if norm:
             window = window / window.sum()
 
-        return self.convolve(window)
+        return self._convolve_kernel(window, stacklevel=3)
 
     def decimate(self, down, order=8, filter_type="iir", ep=None):
         """

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -652,6 +652,62 @@ class TestTimeSeriesGeneral:
                 tsd.convolve(np.ones(3), ep=[1, 2, 3, 4])
             assert str(e_info.value) == "ep should be an object of type IntervalSet"
 
+    @pytest.mark.parametrize(
+        "kernel_size, expected",
+        [
+            (99, None),
+            (100, None),
+            (
+                101,
+                "Kernel size (101 samples) is larger than the number of samples in "
+                "1 out of 1 epochs (shortest epoch has 100 samples).",
+            ),
+        ],
+    )
+    def test_convolve_warns_kernel_larger_than_epoch(self, tsd, kernel_size, expected):
+        if not isinstance(tsd, nap.Ts):
+            if expected is None:
+                with warnings.catch_warnings():
+                    warnings.simplefilter("error")
+                    tsd.convolve(np.ones(kernel_size))
+            else:
+                with pytest.warns(UserWarning) as record:
+                    tsd.convolve(np.ones(kernel_size))
+                message = str(record[0].message)
+                assert message.startswith(expected)
+                assert "zero-padded" in message
+                # the warning points to the caller, not to pynapple internals
+                assert record[0].filename == __file__
+
+    def test_convolve_warns_only_for_short_epochs(self, tsd):
+        if not isinstance(tsd, nap.Ts):
+            # 11 samples in the first epoch, 40 in the second one
+            ep = nap.IntervalSet(start=[0, 60], end=[10, 99])
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                tsd.convolve(np.ones(11), ep=ep)
+
+            with pytest.warns(
+                UserWarning,
+                match=re.escape(
+                    "Kernel size (12 samples) is larger than the number of samples in "
+                    "1 out of 2 epochs (shortest epoch has 11 samples)."
+                ),
+            ):
+                tsd.convolve(np.ones(12), ep=ep)
+
+    def test_smooth_warns_kernel_larger_than_epoch(self, tsd):
+        if not isinstance(tsd, nap.Ts):
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                tsd.smooth(std=2, windowsize=10)
+
+            with pytest.warns(UserWarning, match="zero-padded") as record:
+                tsd.smooth(std=1)
+            # the warning points to the `smooth` call, not to the internal convolution
+            assert record[0].filename == __file__
+
     def test_convolve_1d_kernel(self, tsd):
         array = np.random.randn(10)
         if not isinstance(tsd, nap.Ts):


### PR DESCRIPTION
This pull request enhances the convolution and smoothing operations in the `TimeSeries` class by improving user feedback and internal structure. It introduces warnings when the convolution kernel or smoothing window is larger than the number of samples in any epoch, helping users avoid unintended artifacts due to zero-padding. The implementation also refactors code for better maintainability and adds comprehensive tests to verify the new warning behavior.

**User-facing improvements:**

* Added documentation and runtime warnings to `convolve` and `smooth` methods to inform users when the kernel/window is larger than the number of samples in an epoch, which can cause artifacts due to zero-padding. [[1]](diffhunk://#diff-6228284cbf577fa4fbaa47c79322afa9dc534b13adb89bce6419f51187af7ff7R536-R539) [[2]](diffhunk://#diff-6228284cbf577fa4fbaa47c79322afa9dc534b13adb89bce6419f51187af7ff7R649-R652)
* The warning message includes details about the affected epochs and suggests how to mitigate the issue.

**Code structure and maintainability:**

* Refactored the convolution logic into a private `_convolve_kernel` method, allowing both `convolve` and `smooth` to share the same implementation and correctly propagate warning stack traces. [[1]](diffhunk://#diff-6228284cbf577fa4fbaa47c79322afa9dc534b13adb89bce6419f51187af7ff7R557-R564) [[2]](diffhunk://#diff-6228284cbf577fa4fbaa47c79322afa9dc534b13adb89bce6419f51187af7ff7L676-R707)

**Testing improvements:**

* Added new tests in `test_time_series.py` to ensure warnings are raised appropriately when the kernel/window is too large, and that the warnings point to the correct user code location.