### PR TITLE
small fix for interface neurosuite

### DIFF
--- a/pynapple/io/interface_neurosuite.py
+++ b/pynapple/io/interface_neurosuite.py
@@ -181,9 +181,19 @@ def parse_neuroscope_xml(xml_path):
         spike_groups.append(
             {
                 "channels": channels,
-                "n_samples": int(_text(group, "nSamples")) if _text(group, "nSamples") else None,
-                "n_features": int(_text(group, "nFeatures")) if _text(group, "nFeatures") else None,
-                "peak_sample_index": int(_text(group, "peakSampleIndex")) if _text(group, "peakSampleIndex") else None,
+                "n_samples": (
+                    int(_text(group, "nSamples")) if _text(group, "nSamples") else None
+                ),
+                "n_features": (
+                    int(_text(group, "nFeatures"))
+                    if _text(group, "nFeatures")
+                    else None
+                ),
+                "peak_sample_index": (
+                    int(_text(group, "peakSampleIndex"))
+                    if _text(group, "peakSampleIndex")
+                    else None
+                ),
             }
         )
 

--- a/pynapple/io/interface_neurosuite.py
+++ b/pynapple/io/interface_neurosuite.py
@@ -181,9 +181,9 @@ def parse_neuroscope_xml(xml_path):
         spike_groups.append(
             {
                 "channels": channels,
-                "n_samples": int(_text(group, "nSamples")),
-                "n_features": int(_text(group, "nFeatures")),
-                "peak_sample_index": int(_text(group, "peakSampleIndex")),
+                "n_samples": int(_text(group, "nSamples")) if _text(group, "nSamples") else None,
+                "n_features": int(_text(group, "nFeatures")) if _text(group, "nFeatures") else None,
+                "peak_sample_index": int(_text(group, "peakSampleIndex")) if _text(group, "peakSampleIndex") else None,
             }
         )
 
@@ -193,18 +193,19 @@ def parse_neuroscope_xml(xml_path):
     # Units (clusters)
     # --------------------
     units = []
-    for unit in root.find("units").findall("unit"):
-        units.append(
-            {
-                "group": int(_text(unit, "group")),
-                "cluster": int(_text(unit, "cluster")),
-                "structure": _text(unit, "structure"),
-                "type": _text(unit, "type"),
-                "isolation_distance": _text(unit, "isolationDistance"),
-                "quality": _text(unit, "quality"),
-                "notes": _text(unit, "notes"),
-            }
-        )
+    if root.find("units") is not None:
+        for unit in root.find("units").findall("unit"):
+            units.append(
+                {
+                    "group": int(_text(unit, "group")),
+                    "cluster": int(_text(unit, "cluster")),
+                    "structure": _text(unit, "structure"),
+                    "type": _text(unit, "type"),
+                    "isolation_distance": _text(unit, "isolationDistance"),
+                    "quality": _text(unit, "quality"),
+                    "notes": _text(unit, "notes"),
+                }
+            )
 
     out["units"] = units
 


### PR DESCRIPTION
This pull request improves the robustness of the `parse_neuroscope_xml` function in `pynapple/io/interface_neurosuite.py` by making the parsing of spike group and unit information more resilient to missing or incomplete XML fields.

**Enhancements to XML parsing robustness:**

* Modified the extraction of `n_samples`, `n_features`, and `peak_sample_index` from spike group XML nodes to set their values to `None` if the corresponding XML fields are missing or empty, instead of raising an exception.
* Added a check to ensure that the code only attempts to parse unit information if the `<units>` XML node exists, preventing errors when this section is absent.