### PR TITLE
Allow IntervalSet events in compute_event_triggered_average

### DIFF
--- a/doc/releases.md
+++ b/doc/releases.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- `compute_event_triggered_average` accepts an `IntervalSet` and uses each
+  interval start as an event.
 
 ### 0.11.4 (2026-08-19)
 

--- a/doc/releases.md
+++ b/doc/releases.md
@@ -2,8 +2,6 @@
 
 ### Unreleased
 
-- `compute_event_triggered_average` accepts an `IntervalSet` and uses each
-  interval start as an event.
 
 ### 0.11.4 (2026-08-19)
 

--- a/doc/user_guide/08_perievent.md
+++ b/doc/user_guide/08_perievent.md
@@ -355,6 +355,16 @@ plt.title("Spike triggered average \n nap.compute_event_triggered_average(featur
 plt.tight_layout();
 ```
 
+An `IntervalSet` can also be passed as the events. In this case, the start of
+each interval is used as the alignment time:
+
+```{code-cell} ipython3
+event_intervals = nap.IntervalSet(start=[100, 300, 500], end=[101, 302, 501])
+interval_eta = nap.compute_event_triggered_average(
+    feature, event_intervals, binsize=0.02, window=(-5, 5)
+)
+```
+
 ### Multiple units
 
 The same function can be used for a group of units.

--- a/pynapple/process/perievent.py
+++ b/pynapple/process/perievent.py
@@ -31,10 +31,11 @@ def compute_event_triggered_average(
     ----------
     data : Tsd, TsdFrame, or TsdTensor
         The continuous timeseries to use as the feature (must be regularly sampled).
-    events : Ts, Tsd, TsdFrame, TsdTensor, or TsGroup
+    events : Ts, Tsd, TsdFrame, TsdTensor, TsGroup, or IntervalSet
         The events (or spike trains) to align to. If a ``TsGroup``, each unit's
         spikes are binned and used as a separate event count vector.
-        If not a ``Ts``, we simply take the timestamps of the object.
+        If an ``IntervalSet``, the start of each interval is used as an event.
+        For other time-series objects, only the timestamps are used.
     binsize : float or int
         The bin size.
     window : int, float, or tuple
@@ -55,7 +56,7 @@ def compute_event_triggered_average(
         If ``time_unit`` is invalid, ``window`` format is invalid, or ``data`` is not
         regularly sampled.
     TypeError
-        If ``data`` or ``events`` are not valid timeseries objects.
+        If ``data`` or ``events`` have unsupported types.
 
     Examples
     --------
@@ -161,10 +162,15 @@ def compute_event_triggered_average(
             f"data should be a continuous time series (Tsd, TsdFrame, or TsdTensor): {type(data)}"
         )
 
+    if isinstance(events, nap.IntervalSet):
+        events = nap.Ts(events.start)
+
     if not isinstance(
         events, (nap.Ts, nap.Tsd, nap.TsdFrame, nap.TsdTensor, nap.TsGroup)
     ):
-        raise TypeError(f"events should be a time series object: {type(events)}")
+        raise TypeError(
+            f"events should be a time series object or an IntervalSet: {type(events)}"
+        )
 
     if epochs is None:
         epochs = data.time_support

--- a/tests/test_perievent.py
+++ b/tests/test_perievent.py
@@ -366,6 +366,48 @@ class TestComputeEventTriggeredAverage:
         assert eta.shape[1] == 2
         assert list(eta.columns) == [0, 1]
 
+    @pytest.mark.parametrize("time_units, scale", [("s", 1.0), ("ms", 1_000.0)])
+    def test_intervalset_events_use_interval_starts(self, time_units, scale):
+        times = np.arange(0, 10, 0.1)
+        feature = nap.Tsd(t=times, d=np.sin(times))
+        intervals = nap.IntervalSet(
+            start=np.array([1.0, 3.0, 5.0]) * scale,
+            end=np.array([1.2, 3.8, 5.4]) * scale,
+            time_units=time_units,
+        )
+
+        actual = nap.compute_event_triggered_average(
+            feature, intervals, binsize=0.1, window=0.5
+        )
+        expected = nap.compute_event_triggered_average(
+            feature, nap.Ts(intervals.start), binsize=0.1, window=0.5
+        )
+
+        np.testing.assert_array_equal(actual.index.values, expected.index.values)
+        np.testing.assert_array_equal(actual.values, expected.values)
+
+    def test_intervalset_events_with_epochs(self):
+        times = np.arange(0, 10, 0.1)
+        feature = nap.Tsd(t=times, d=np.sin(times))
+        intervals = nap.IntervalSet(
+            start=[1.0, 3.0, 5.0, 7.0], end=[1.2, 3.4, 5.6, 7.8]
+        )
+        epochs = nap.IntervalSet(start=[0.0, 6.0], end=[2.0, 9.0])
+
+        actual = nap.compute_event_triggered_average(
+            feature, intervals, binsize=0.1, window=0.5, epochs=epochs
+        )
+        expected = nap.compute_event_triggered_average(
+            feature,
+            nap.Ts(intervals.start),
+            binsize=0.1,
+            window=0.5,
+            epochs=epochs,
+        )
+
+        np.testing.assert_array_equal(actual.index.values, expected.index.values)
+        np.testing.assert_array_equal(actual.values, expected.values)
+
     def test_tsdframe_returns_tsdtensor(self):
         times = np.arange(0, 10, 0.1)
         features = nap.TsdFrame(
@@ -494,7 +536,9 @@ class TestComputeEventTriggeredAverage:
     def test_invalid_events_type(self, bad_events):
         times = np.arange(0, 10, 0.1)
         feature = nap.Tsd(t=times, d=np.sin(times))
-        with pytest.raises(TypeError, match="events should be a time series object"):
+        with pytest.raises(
+            TypeError, match="events should be a time series object or an IntervalSet"
+        ):
             nap.compute_event_triggered_average(
                 feature, bad_events, binsize=0.1, window=0.5
             )


### PR DESCRIPTION
Closes #637.

`compute_event_triggered_average` can now take an `IntervalSet` directly. The start of each interval is used as the event time, matching the existing manual `nap.Ts(intervals.start)` approach.

The tests cover seconds and milliseconds, equivalence with the explicit `Ts` conversion, and the use of a separate `epochs` argument. The API documentation and user guide are updated as well.
