### PR TITLE
Add lagged cross-correlation for TsdFrame

### DIFF
--- a/doc/user_guide/02_input_output.md
+++ b/doc/user_guide/02_input_output.md
@@ -516,7 +516,7 @@ print(project["sub-A2929"]["A2929-200711"]["pynapplenwb"]["A2929-200711"])
 
 A good practice for sharing datasets is to write as many 
 metainformation as possible. Following 
-[BIDS](https://bids-standard.github.io/bids-starter-kit/index.html) 
+[BIDS](https://github.com/bids-standard/bids-starter-kit)
 specifications, any data files should be accompanied by a JSON sidecar file.
 
 This is possible using the `Folder` class of pynapple with the argument `description`.

--- a/doc/user_guide/05_correlograms_isi.md
+++ b/doc/user_guide/05_correlograms_isi.md
@@ -67,6 +67,42 @@ print(crosscorrs)
 
 Column name `(0, 1)` is read as cross-correlogram of neuron 0 and 1 with neuron 0 being the reference time.
 
+## Lagged cross-correlations
+
+Lagged cross-correlation measures how continuous signals vary together at different time offsets. The input is a regularly sampled `TsdFrame`; no binning is needed because its columns are already sampled on the same time axis.
+
+```{code-cell} ipython3
+rng = np.random.default_rng(1)
+timestamps = np.arange(1000) / 100
+reference = rng.normal(size=len(timestamps))
+delayed = np.r_[np.zeros(10), reference[:-10]]
+signals = nap.TsdFrame(
+    t=timestamps,
+    d=np.column_stack((reference, delayed)),
+    columns=["reference", "delayed"],
+    time_support=nap.IntervalSet(0, 10),
+)
+
+lagged_corr = nap.compute_lagged_crosscorrelation(
+    signals, windowsize=0.5, time_units="s"
+)
+print(lagged_corr)
+```
+
+The output is a pandas DataFrame with lags in seconds as its index and signal pairs as its columns. Here the correlation peaks at `+0.1` seconds: positive lags mean that the second signal follows the first.
+
+Passing two `TsdFrame` objects computes all cross-frame column pairs. Their timestamps must match.
+
+```{code-cell} ipython3
+reference_frame = signals[:, [0]]
+delayed_frame = signals[:, [1]]
+cross_frame_corr = nap.compute_lagged_crosscorrelation(
+    (reference_frame, delayed_frame), windowsize=0.5
+)
+```
+
+The optional `epochs` argument restricts the calculation. Valid observations are pooled across epochs for each lag, but pairs never cross an epoch boundary.
+
 ## Event-correlograms
 
 Event-correlograms count the number of event in the `TsGroup` based on an `event` timestamps object. 

--- a/pynapple/process/__init__.py
+++ b/pynapple/process/__init__.py
@@ -3,6 +3,7 @@ from .correlograms import (
     compute_crosscorrelogram,
     compute_eventcorrelogram,
     compute_isi_distribution,
+    compute_lagged_crosscorrelation,
 )
 from .decoding import decode_1d, decode_2d, decode_bayes, decode_template
 from .filtering import (

--- a/pynapple/process/correlograms.py
+++ b/pynapple/process/correlograms.py
@@ -161,6 +161,224 @@ def _cross_correlogram(
     return C, B
 
 
+@jit(nopython=True, cache=True)
+def _lagged_crosscorrelation(
+    data1: npt.NDArray[np.float64],
+    data2: npt.NDArray[np.float64],
+    counts: npt.NDArray[np.int64],
+    pairs1: npt.NDArray[np.int64],
+    pairs2: npt.NDArray[np.int64],
+    max_lag: int,
+) -> npt.NDArray[np.float64]:
+    """Compute Pearson correlations for lagged column pairs within epochs."""
+    n_lags = 2 * max_lag + 1
+    n_pairs = len(pairs1)
+    correlations = np.full((n_lags, n_pairs), np.nan)
+
+    # Shift each stream before the online updates to preserve small variations.
+    anchors1 = np.empty(data1.shape[1])
+    anchors2 = np.empty(data2.shape[1])
+    means1 = np.empty(data1.shape[1])
+    means2 = np.empty(data2.shape[1])
+    sums_of_squares1 = np.empty(data1.shape[1])
+    sums_of_squares2 = np.empty(data2.shape[1])
+    deltas1 = np.empty(data1.shape[1])
+    residuals2 = np.empty(data2.shape[1])
+    sums_of_products = np.empty(n_pairs)
+
+    for lag_index in range(n_lags):
+        lag = lag_index - max_lag
+        means1.fill(0.0)
+        means2.fill(0.0)
+        sums_of_squares1.fill(0.0)
+        sums_of_squares2.fill(0.0)
+        sums_of_products.fill(0.0)
+        n_observations = 0
+        epoch_start = 0
+
+        for count in counts:
+            n_valid = count - abs(lag)
+            if n_valid > 0:
+                if lag >= 0:
+                    start1 = epoch_start
+                    start2 = epoch_start + lag
+                else:
+                    start1 = epoch_start - lag
+                    start2 = epoch_start
+
+                for sample in range(n_valid):
+                    if n_observations == 0:
+                        anchors1[:] = data1[start1 + sample]
+                        anchors2[:] = data2[start2 + sample]
+                    n_observations += 1
+
+                    for column in range(data1.shape[1]):
+                        value = data1[start1 + sample, column] - anchors1[column]
+                        delta = value - means1[column]
+                        means1[column] += delta / n_observations
+                        sums_of_squares1[column] += delta * (value - means1[column])
+                        deltas1[column] = delta
+
+                    for column in range(data2.shape[1]):
+                        value = data2[start2 + sample, column] - anchors2[column]
+                        delta = value - means2[column]
+                        means2[column] += delta / n_observations
+                        residual = value - means2[column]
+                        sums_of_squares2[column] += delta * residual
+                        residuals2[column] = residual
+
+                    for pair in range(n_pairs):
+                        sums_of_products[pair] += (
+                            deltas1[pairs1[pair]] * residuals2[pairs2[pair]]
+                        )
+
+            epoch_start += count
+
+        if n_observations < 2:
+            continue
+        for pair in range(n_pairs):
+            denominator = np.sqrt(
+                sums_of_squares1[pairs1[pair]] * sums_of_squares2[pairs2[pair]]
+            )
+            if denominator > 0.0:
+                correlation = sums_of_products[pair] / denominator
+                correlations[lag_index, pair] = min(1.0, max(-1.0, correlation))
+
+    return correlations
+
+
+def compute_lagged_crosscorrelation(
+    data: Union[
+        nap.TsdFrame,
+        tuple[nap.TsdFrame, nap.TsdFrame],
+        list[nap.TsdFrame],
+    ],
+    windowsize: float,
+    epochs: Optional[nap.IntervalSet] = None,
+    time_units: str = "s",
+) -> pd.DataFrame:
+    """
+    Compute lagged Pearson correlations between columns of continuous data.
+
+    If ``data`` is one ``TsdFrame``, correlations are computed for every unique
+    pair of columns. If ``data`` is a tuple or list of two ``TsdFrame`` objects,
+    correlations are computed for every pair of columns across the two frames.
+    Positive lags indicate that the second signal follows the first signal.
+
+    Valid observations are pooled across epochs for each lag. Pairs never cross
+    an epoch boundary.
+
+    Parameters
+    ----------
+    data : TsdFrame or tuple/list of two TsdFrames
+        The regularly sampled continuous signals to correlate. Two frames must
+        have identical timestamps.
+    windowsize : float
+        Maximum lag duration on either side of zero.
+    epochs : IntervalSet, optional
+        Epochs over which correlations are computed. If None, the shared time
+        support of the input data is used.
+    time_units : str, optional
+        Unit of ``windowsize`` (``"s"`` [default], ``"ms"``, or ``"us"``).
+
+    Returns
+    -------
+    pandas.DataFrame
+        Correlations indexed by lag in seconds, with signal pairs as columns.
+
+    Raises
+    ------
+    TypeError
+        If the inputs have invalid types.
+    ValueError
+        If ``windowsize`` is negative, ``time_units`` is invalid, or two input
+        frames do not have identical timestamps.
+    RuntimeError
+        If the input is not regularly sampled or its sampling interval cannot
+        be determined.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import pynapple as nap
+    >>> t = np.arange(100) / 10
+    >>> frame = nap.TsdFrame(t=t, d=np.column_stack((np.sin(t), np.cos(t))))
+    >>> correlation = nap.compute_lagged_crosscorrelation(frame, windowsize=0.5)
+    """
+    if isinstance(data, (tuple, list)):
+        if len(data) != 2 or not all(isinstance(d, nap.TsdFrame) for d in data):
+            raise TypeError(
+                "data must be a TsdFrame or a tuple/list of two TsdFrame objects."
+            )
+        data1, data2 = data
+        if not np.array_equal(data1.index.values, data2.index.values):
+            raise ValueError("The two TsdFrame objects must have identical timestamps.")
+        if data1.shape[1] == 0 or data2.shape[1] == 0:
+            raise ValueError("Each TsdFrame must contain at least one column.")
+        time_support = data1.time_support.intersect(data2.time_support)
+        pair_indices = list(product(range(data1.shape[1]), range(data2.shape[1])))
+        pair_labels = list(product(data1.columns, data2.columns))
+    else:
+        if not isinstance(data, nap.TsdFrame):
+            raise TypeError(
+                "data must be a TsdFrame or a tuple/list of two TsdFrame objects."
+            )
+        data1 = data2 = data
+        if data.shape[1] < 2:
+            raise ValueError("A single TsdFrame must contain at least two columns.")
+        time_support = data.time_support
+        pair_indices = list(combinations(range(data.shape[1]), 2))
+        pair_labels = list(combinations(data.columns, 2))
+
+    if not isinstance(windowsize, Number):
+        raise TypeError("windowsize must be a number.")
+    if not np.isfinite(windowsize) or windowsize < 0:
+        raise ValueError("windowsize must be finite and non-negative.")
+    if epochs is not None and not isinstance(epochs, nap.IntervalSet):
+        raise TypeError("epochs must be an IntervalSet or None.")
+    if not isinstance(time_units, str):
+        raise TypeError("time_units must be a string.")
+
+    if np.iscomplexobj(data1.values) or np.iscomplexobj(data2.values):
+        raise TypeError("Lagged cross-correlation requires real-valued data.")
+
+    if epochs is not None:
+        time_support = time_support.intersect(epochs)
+
+    if not nap.utils._is_regularly_sampled(data1):
+        raise RuntimeError("Lagged cross-correlation requires regularly sampled data.")
+    time_differences = data1.time_diff().values
+    if len(time_differences) == 0:
+        raise RuntimeError("The sampling interval could not be determined.")
+    sampling_interval = time_differences[0]
+    if not np.isfinite(sampling_interval) or sampling_interval <= 0:
+        raise RuntimeError("The sampling interval must be finite and positive.")
+
+    window_seconds = nap.TsIndex.format_timestamps(
+        np.array([windowsize], dtype=np.float64), time_units
+    )[0]
+    max_lag = int(np.floor(window_seconds / sampling_interval + 1e-12))
+
+    indices, counts = nap._jitted_functions.jitrestrict_with_count(
+        data1.index.values, time_support.start, time_support.end
+    )
+    pairs1 = np.asarray([pair[0] for pair in pair_indices], dtype=np.int64)
+    pairs2 = np.asarray([pair[1] for pair in pair_indices], dtype=np.int64)
+
+    correlations = _lagged_crosscorrelation(
+        np.asarray(data1.values[indices], dtype=np.float64),
+        np.asarray(data2.values[indices], dtype=np.float64),
+        counts,
+        pairs1,
+        pairs2,
+        max_lag,
+    )
+    lags = np.arange(-max_lag, max_lag + 1) * sampling_interval
+    columns = pd.MultiIndex.from_tuples(pair_labels)
+
+    return pd.DataFrame(correlations, index=lags, columns=columns, dtype=float)
+
+
 @_validate_correlograms_inputs
 def compute_autocorrelogram(
     group: nap.TsGroup,

--- a/tests/test_correlograms.py
+++ b/tests/test_correlograms.py
@@ -193,6 +193,341 @@ def test_correlograms_type_errors_event(func, args, msg):
         func(*args)
 
 
+def _reference_lagged_correlation(data1, data2, counts, lag, pairs):
+    values1 = []
+    values2 = []
+    start = 0
+    for count in counts:
+        end = start + count
+        if lag >= 0:
+            values1.append(data1[start : end - lag])
+            values2.append(data2[start + lag : end])
+        else:
+            values1.append(data1[start - lag : end])
+            values2.append(data2[start : end + lag])
+        start = end
+
+    values1 = np.concatenate(values1)
+    values2 = np.concatenate(values2)
+    return np.array([np.corrcoef(values1[:, i], values2[:, j])[0, 1] for i, j in pairs])
+
+
+def test_lagged_crosscorrelation_matches_numpy_and_lag_sign():
+    rng = np.random.default_rng(42)
+    reference = rng.normal(size=100)
+    delayed = np.empty_like(reference)
+    delayed[:3] = rng.normal(size=3)
+    delayed[3:] = reference[:-3]
+    timestamps = np.arange(100) / 10
+    frame = nap.TsdFrame(
+        t=timestamps,
+        d=np.column_stack((reference, delayed, rng.normal(size=100))),
+        columns=["reference", "delayed", "noise"],
+        time_support=nap.IntervalSet(0, 10),
+    )
+
+    result = nap.compute_lagged_crosscorrelation(frame, windowsize=0.5)
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result.columns) == [
+        ("reference", "delayed"),
+        ("reference", "noise"),
+        ("delayed", "noise"),
+    ]
+    np.testing.assert_allclose(result.index, np.arange(-5, 6) / 10)
+    assert result[("reference", "delayed")].idxmax() == pytest.approx(0.3)
+    for lag_index, lag in enumerate(range(-5, 6)):
+        expected = _reference_lagged_correlation(
+            frame.values,
+            frame.values,
+            np.array([len(frame)]),
+            lag,
+            [(0, 1), (0, 2), (1, 2)],
+        )
+        np.testing.assert_allclose(result.iloc[lag_index], expected)
+
+
+@pytest.mark.parametrize("container", [tuple, list])
+def test_lagged_crosscorrelation_two_frames(container):
+    rng = np.random.default_rng(1)
+    timestamps = np.arange(20) / 2
+    support = nap.IntervalSet(0, 10)
+    frame1 = nap.TsdFrame(
+        t=timestamps,
+        d=rng.normal(size=(20, 2)),
+        columns=["a", "b"],
+        time_support=support,
+    )
+    frame2 = nap.TsdFrame(
+        t=timestamps,
+        d=rng.normal(size=(20, 2)),
+        columns=["c", "d"],
+        time_support=support,
+    )
+
+    result = nap.compute_lagged_crosscorrelation(container((frame1, frame2)), 1)
+
+    pairs = [(0, 0), (0, 1), (1, 0), (1, 1)]
+    assert list(result.columns) == [("a", "c"), ("a", "d"), ("b", "c"), ("b", "d")]
+    for lag_index, lag in enumerate(range(-2, 3)):
+        expected = _reference_lagged_correlation(
+            frame1.values,
+            frame2.values,
+            np.array([20]),
+            lag,
+            pairs,
+        )
+        np.testing.assert_allclose(result.iloc[lag_index], expected)
+
+
+def test_lagged_crosscorrelation_pools_epochs_without_crossing_boundaries():
+    rng = np.random.default_rng(2)
+    timestamps = np.r_[np.arange(5), np.arange(10, 15)]
+    support = nap.IntervalSet(start=[0, 10], end=[5, 15])
+    values = rng.normal(size=(10, 2))
+    frame = nap.TsdFrame(
+        t=timestamps,
+        d=values,
+        columns=["a", "b"],
+        time_support=support,
+    )
+
+    result = nap.compute_lagged_crosscorrelation(frame, windowsize=2)
+
+    for lag_index, lag in enumerate(range(-2, 3)):
+        expected = _reference_lagged_correlation(
+            values, values, np.array([5, 5]), lag, [(0, 1)]
+        )
+        np.testing.assert_allclose(result.iloc[lag_index], expected)
+
+    pooled_across_boundary = np.corrcoef(values[:-1, 0], values[1:, 1])[0, 1]
+    assert result.loc[1.0, ("a", "b")] != pytest.approx(pooled_across_boundary)
+
+
+def test_lagged_crosscorrelation_epochs_are_intersected_with_time_support():
+    rng = np.random.default_rng(3)
+    timestamps = np.r_[np.arange(5), np.arange(10, 15)]
+    support = nap.IntervalSet(start=[0, 10], end=[5, 15])
+    frame = nap.TsdFrame(
+        t=timestamps,
+        d=rng.normal(size=(10, 2)),
+        time_support=support,
+    )
+
+    result = nap.compute_lagged_crosscorrelation(
+        frame, windowsize=1, epochs=nap.IntervalSet(0, 15)
+    )
+    expected = _reference_lagged_correlation(
+        frame.values, frame.values, np.array([5, 5]), 1, [(0, 1)]
+    )
+
+    np.testing.assert_allclose(result.loc[1.0], expected)
+
+
+def test_lagged_crosscorrelation_nan_and_constant_values_propagate():
+    timestamps = np.arange(5)
+    frame = nap.TsdFrame(
+        t=timestamps,
+        d=np.column_stack((np.arange(5), [0.0, 1.0, np.nan, 3.0, 4.0], np.ones(5))),
+        columns=["a", "nan", "constant"],
+        time_support=nap.IntervalSet(0, 5),
+    )
+
+    result = nap.compute_lagged_crosscorrelation(frame, windowsize=0)
+
+    assert np.isnan(result.loc[0.0, ("a", "nan")])
+    assert np.isnan(result.loc[0.0, ("a", "constant")])
+
+
+def test_lagged_crosscorrelation_is_stable_for_large_offsets():
+    rng = np.random.default_rng(4)
+    values = 1e12 + rng.normal(size=(1000, 2))
+    frame = nap.TsdFrame(
+        t=np.arange(1000),
+        d=values,
+        time_support=nap.IntervalSet(0, 1000),
+    )
+
+    result = nap.compute_lagged_crosscorrelation(frame, windowsize=0)
+    expected = np.corrcoef(values[:, 0], values[:, 1])[0, 1]
+
+    np.testing.assert_allclose(result.iloc[0, 0], expected, atol=1e-8)
+
+
+def test_lagged_crosscorrelation_is_symmetric_when_inputs_are_swapped():
+    rng = np.random.default_rng(5)
+    timestamps = np.arange(50) / 5
+    support = nap.IntervalSet(0, 10)
+    frame1 = nap.TsdFrame(
+        t=timestamps, d=rng.normal(size=(50, 1)), columns=["a"], time_support=support
+    )
+    frame2 = nap.TsdFrame(
+        t=timestamps, d=rng.normal(size=(50, 1)), columns=["b"], time_support=support
+    )
+
+    forward = nap.compute_lagged_crosscorrelation((frame1, frame2), 1)
+    backward = nap.compute_lagged_crosscorrelation((frame2, frame1), 1)
+
+    np.testing.assert_allclose(
+        forward[("a", "b")].values, backward[("b", "a")].values[::-1]
+    )
+
+
+def test_lagged_crosscorrelation_time_units():
+    timestamps = np.arange(10) / 1000
+    frame = nap.TsdFrame(
+        t=timestamps,
+        d=np.column_stack((np.arange(10), np.arange(10))),
+        time_support=nap.IntervalSet(0, 0.01),
+    )
+
+    result = nap.compute_lagged_crosscorrelation(frame, windowsize=2, time_units="ms")
+
+    np.testing.assert_allclose(result.index, np.arange(-2, 3) / 1000)
+
+
+def test_lagged_crosscorrelation_uses_timestamp_spacing():
+    timestamps = np.arange(10) / 10
+    frame = nap.TsdFrame(
+        t=timestamps,
+        d=np.column_stack((np.arange(10), np.arange(10))),
+    )
+
+    result = nap.compute_lagged_crosscorrelation(frame, windowsize=0.2)
+
+    np.testing.assert_allclose(result.index, np.arange(-2, 3) / 10)
+
+
+def test_lagged_crosscorrelation_window_smaller_than_sample_interval():
+    frame = nap.TsdFrame(
+        t=np.arange(10) / 10,
+        d=np.column_stack((np.arange(10), np.arange(10))),
+    )
+
+    result = nap.compute_lagged_crosscorrelation(frame, windowsize=0.05)
+
+    np.testing.assert_array_equal(result.index, np.array([0.0]))
+    assert result.iloc[0, 0] == pytest.approx(1.0)
+
+
+def test_lagged_crosscorrelation_lags_without_observations_are_nan():
+    frame = nap.TsdFrame(
+        t=np.arange(3),
+        d=np.column_stack((np.arange(3), np.arange(3))),
+        time_support=nap.IntervalSet(0, 3),
+    )
+
+    result = nap.compute_lagged_crosscorrelation(frame, windowsize=3)
+
+    assert np.isnan(result.loc[-3.0, (0, 1)])
+    assert np.isnan(result.loc[3.0, (0, 1)])
+
+
+def test_lagged_crosscorrelation_empty_epochs_are_nan():
+    frame = nap.TsdFrame(
+        t=np.arange(5),
+        d=np.column_stack((np.arange(5), np.arange(5))),
+        time_support=nap.IntervalSet(0, 5),
+    )
+
+    result = nap.compute_lagged_crosscorrelation(
+        frame, windowsize=1, epochs=nap.IntervalSet(10, 11)
+    )
+
+    assert result.isna().all().all()
+
+
+@pytest.mark.parametrize(
+    "data, windowsize, epochs, time_units, error, message",
+    [
+        (np.arange(3), 1, None, "s", TypeError, "data must be a TsdFrame"),
+        ([], 1, None, "s", TypeError, "data must be a TsdFrame"),
+        (None, "one", None, "s", TypeError, "data must be a TsdFrame"),
+    ],
+)
+def test_lagged_crosscorrelation_invalid_data(
+    data, windowsize, epochs, time_units, error, message
+):
+    with pytest.raises(error, match=message):
+        nap.compute_lagged_crosscorrelation(data, windowsize, epochs, time_units)
+
+
+def test_lagged_crosscorrelation_invalid_parameters():
+    frame = nap.TsdFrame(
+        t=np.arange(5),
+        d=np.column_stack((np.arange(5), np.arange(5))),
+        time_support=nap.IntervalSet(0, 5),
+    )
+
+    with pytest.raises(TypeError, match="windowsize must be a number"):
+        nap.compute_lagged_crosscorrelation(frame, "one")
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        nap.compute_lagged_crosscorrelation(frame, -1)
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        nap.compute_lagged_crosscorrelation(frame, np.inf)
+    with pytest.raises(TypeError, match="epochs must be an IntervalSet"):
+        nap.compute_lagged_crosscorrelation(frame, 1, epochs=[(0, 1)])
+    with pytest.raises(TypeError, match="time_units must be a string"):
+        nap.compute_lagged_crosscorrelation(frame, 1, time_units=1)
+    with pytest.raises(ValueError, match="unrecognized time units type"):
+        nap.compute_lagged_crosscorrelation(frame, 1, time_units="minutes")
+
+
+def test_lagged_crosscorrelation_requires_matching_timestamps():
+    frame1 = nap.TsdFrame(t=np.arange(5), d=np.arange(5)[:, None])
+    frame2 = nap.TsdFrame(t=np.arange(5) + 0.1, d=np.arange(5)[:, None])
+
+    with pytest.raises(ValueError, match="identical timestamps"):
+        nap.compute_lagged_crosscorrelation((frame1, frame2), 1)
+
+
+def test_lagged_crosscorrelation_requires_two_columns_for_one_frame():
+    frame = nap.TsdFrame(t=np.arange(5), d=np.arange(5)[:, None])
+
+    with pytest.raises(ValueError, match="at least two columns"):
+        nap.compute_lagged_crosscorrelation(frame, 1)
+
+
+def test_lagged_crosscorrelation_requires_columns_in_both_frames():
+    timestamps = np.arange(5)
+    empty = nap.TsdFrame(t=timestamps, d=np.empty((5, 0)))
+    frame = nap.TsdFrame(t=timestamps, d=np.arange(5)[:, None])
+
+    with pytest.raises(ValueError, match="at least one column"):
+        nap.compute_lagged_crosscorrelation((empty, frame), 1)
+
+
+def test_lagged_crosscorrelation_requires_regular_sampling():
+    frame = nap.TsdFrame(
+        t=np.array([0.0, 0.1, 0.3, 0.6]),
+        d=np.arange(8).reshape(4, 2),
+    )
+
+    with pytest.raises(RuntimeError, match="regularly sampled"):
+        nap.compute_lagged_crosscorrelation(frame, 1)
+
+
+def test_lagged_crosscorrelation_requires_a_sampling_interval():
+    frame = nap.TsdFrame(
+        t=np.array([0.0]),
+        d=np.array([[1.0, 2.0]]),
+        time_support=nap.IntervalSet(0, 1),
+    )
+
+    with pytest.raises(RuntimeError, match="sampling interval could not be determined"):
+        nap.compute_lagged_crosscorrelation(frame, 0)
+
+
+def test_lagged_crosscorrelation_rejects_complex_data():
+    frame = nap.TsdFrame(
+        t=np.arange(5),
+        d=np.column_stack((np.arange(5), np.arange(5))) * (1 + 1j),
+    )
+
+    with pytest.raises(TypeError, match="real-valued data"):
+        nap.compute_lagged_crosscorrelation(frame, 1)
+
+
 #################################################
 # Normal tests
 #################################################


### PR DESCRIPTION
Closes #613.

This adds `compute_lagged_crosscorrelation` for regularly sampled `TsdFrame` data. With one frame, it computes all unique signal pairs; with two frames, it computes all cross-frame pairs.

Observations are pooled across epochs without crossing epoch boundaries. Positive lags indicate that the second signal follows the first.

The calculation uses a JIT-compiled online Pearson update, with the sampling interval taken from the timestamps. Tests cover NumPy equivalence, shifted signals, multiple epochs, numerical stability, invalid inputs and edge cases. The user guide is updated as well.