### PR TITLE
Value from speedups

### DIFF
--- a/doc/user_guide/02_input_output.md
+++ b/doc/user_guide/02_input_output.md
@@ -516,7 +516,7 @@ print(project["sub-A2929"]["A2929-200711"]["pynapplenwb"]["A2929-200711"])
 
 A good practice for sharing datasets is to write as many 
 metainformation as possible. Following 
-[BIDS](https://bids-standard.github.io/bids-starter-kit/index.html) 
+[BIDS](https://bids.neuroimaging.io/getting_started/index.html) 
 specifications, any data files should be accompanied by a JSON sidecar file.
 
 This is possible using the `Folder` class of pynapple with the argument `description`.

--- a/pynapple/core/_core_functions.py
+++ b/pynapple/core/_core_functions.py
@@ -58,7 +58,9 @@ def _restrict_ranges(time_array, data_array, starts, ends):
     ir = np.searchsorted(time_array, ends, side="right")
 
     new_time = _concat_ranges(time_array, il, ir, copy=True)
-    new_data = None if data_array is None else _concat_ranges(data_array, il, ir, copy=True)
+    new_data = (
+        None if data_array is None else _concat_ranges(data_array, il, ir, copy=True)
+    )
 
     return new_time, new_data
 
@@ -90,8 +92,12 @@ def _concat_ranges(array, range_starts, range_stops, copy):
     counts = range_stops - range_starts
     total = int(np.sum(counts))
 
-    if not copy and total and (
-        len(range_starts) == 1 or np.array_equal(range_stops[:-1], range_starts[1:])
+    if (
+        not copy
+        and total
+        and (
+            len(range_starts) == 1 or np.array_equal(range_stops[:-1], range_starts[1:])
+        )
     ):
         return array[range_starts[0] : range_stops[-1]]
 

--- a/pynapple/core/_core_functions.py
+++ b/pynapple/core/_core_functions.py
@@ -101,8 +101,10 @@ def _value_from(
     else:
         mode = 0 if mode == "before" else 2
 
+    new_time_array = time_array[idx_t]
+
     idx = jitvaluefrom(
-        time_array[idx_t],
+        new_time_array,
         time_target_array[idx_target],
         count,
         count_target,
@@ -110,30 +112,41 @@ def _value_from(
         mode=mode,
     )
 
-    new_time_array = time_array[idx_t]
-    nan_idx = np.isnan(idx)
+    # `idx` indexes the *restricted* target and uses NaN for unmatched timestamps.
+    nan_mask = np.isnan(idx)
+    has_nan = bool(nan_mask.any())
 
-    # set the type as default
+    # Composing `idx_target[idx]` gathers the values once, straight out of the full
+    # target, instead of materializing the whole restricted target only to index
+    # into it again. The composed indices are neither sorted nor unique, which
+    # h5py/zarr datasets (``lazy_loading=True``) reject, so those keep the two-step
+    # gather -- there the first, monotonic gather is what loads the data.
+    can_compose = isinstance(data_target_array, np.ndarray)
+
+    # keep the target dtype if it is floating or if every timestamp matched,
+    # otherwise upcast to float to hold the NaNs
     use_type = data_target_array.dtype
+    if has_nan and not np.issubdtype(use_type, np.floating):
+        use_type = np.float64
 
-    # if is already floating or all values are valid, keep type, otherwise use float
-    use_type = (
-        use_type if np.issubdtype(use_type, np.floating) or not any(nan_idx) else float
-    )
-    if not np.issubdtype(use_type, np.floating):
-        new_data_array = np.zeros(
-            (len(new_time_array), *data_target_array.shape[1:]),
-            dtype=use_type,
-        )
+    out_shape = (len(new_time_array), *data_target_array.shape[1:])
+
+    if has_nan:
+        # `use_type` is necessarily floating here
+        new_data_array = np.full(out_shape, np.nan, dtype=use_type)
+        valid = ~nan_mask
+        local = idx[valid].astype(np.int64)
+        if can_compose:
+            new_data_array[valid] = data_target_array[idx_target[local]]
+        else:
+            new_data_array[valid] = data_target_array[idx_target][local]
     else:
-        new_data_array = np.full(
-            (len(new_time_array), *data_target_array.shape[1:]),
-            np.nan,
-            dtype=use_type,
-        )
-
-    idx2 = ~np.isnan(idx)
-    new_data_array[idx2] = data_target_array[idx_target][idx[idx2].astype(int)]
+        local = idx.astype(np.int64)
+        if can_compose:
+            new_data_array = np.empty(out_shape, dtype=use_type)
+            np.take(data_target_array, idx_target[local], axis=0, out=new_data_array)
+        else:
+            new_data_array = data_target_array[idx_target][local]
 
     return new_time_array, new_data_array
 

--- a/pynapple/core/_core_functions.py
+++ b/pynapple/core/_core_functions.py
@@ -19,7 +19,7 @@ from ._jitted_functions import (  # pjitconvolve,
     jitrestrict,
     jitrestrict_with_count,
     jitthreshold,
-    jitvaluefrom,
+    jitvaluefrom_ranges,
 )
 from .utils import get_backend
 
@@ -56,24 +56,52 @@ def _restrict_ranges(time_array, data_array, starts, ends):
     """
     il = np.searchsorted(time_array, starts, side="left")
     ir = np.searchsorted(time_array, ends, side="right")
-    total = int(np.sum(ir - il))
 
-    new_time = np.empty(total, dtype=time_array.dtype)
-    new_data = (
-        None
-        if data_array is None
-        else np.empty((total,) + data_array.shape[1:], dtype=data_array.dtype)
-    )
-
-    pos = 0
-    for k in range(len(il)):
-        count = ir[k] - il[k]
-        new_time[pos : pos + count] = time_array[il[k] : ir[k]]
-        if new_data is not None:
-            new_data[pos : pos + count] = data_array[il[k] : ir[k]]
-        pos += count
+    new_time = _concat_ranges(time_array, il, ir, copy=True)
+    new_data = None if data_array is None else _concat_ranges(data_array, il, ir, copy=True)
 
     return new_time, new_data
+
+
+def _concat_ranges(array, range_starts, range_stops, copy):
+    """Concatenate the slices ``array[range_starts[k]:range_stops[k]]`` along axis 0.
+
+    The ranges must be sorted and non-overlapping. Each is copied with a plain
+    contiguous slice assignment (one memcpy per range), which beats both a
+    fancy-index gather and a numba kernel in the few-range regime.
+
+    Parameters
+    ----------
+    array : ndarray
+        Array to take the ranges from.
+    range_starts, range_stops : ndarray[int]
+        Half-open bounds of each range.
+    copy : bool
+        When False, ranges that happen to tile a single contiguous span are
+        returned as a *view* of ``array`` rather than copied. Callers that hand the
+        result to a user-facing object must weigh that aliasing; pass True to
+        always copy.
+
+    Returns
+    -------
+    ndarray
+        The concatenated ranges.
+    """
+    counts = range_stops - range_starts
+    total = int(np.sum(counts))
+
+    if not copy and total and (
+        len(range_starts) == 1 or np.array_equal(range_stops[:-1], range_starts[1:])
+    ):
+        return array[range_starts[0] : range_stops[-1]]
+
+    out = np.empty((total,) + array.shape[1:], dtype=array.dtype)
+    pos = 0
+    for k in range(len(range_starts)):
+        count = counts[k]
+        out[pos : pos + count] = array[range_starts[k] : range_stops[k]]
+        pos += count
+    return out
 
 
 def _count(time_array, starts, ends, bin_size=None, dtype=None):
@@ -93,60 +121,67 @@ def _value_from(
     ends,
     mode: Literal["closest", "before", "after"] = "closest",
 ):
-    idx_t, count = jitrestrict_with_count(time_array, starts, ends)
-    idx_target, count_target = jitrestrict_with_count(time_target_array, starts, ends)
     # replace flag with int
     if mode == "closest":
         mode = 1
     else:
         mode = 0 if mode == "before" else 2
 
-    new_time_array = time_array[idx_t]
+    # Per-epoch slice boundaries, found with a handful of binary searches instead of
+    # an O(n) scan over each array. IntervalSet guarantees sorted, disjoint and
+    # non-touching epochs, so this reproduces jitrestrict's inclusive
+    # ``start <= t <= end`` selection exactly, and nothing has to be gathered:
+    # the kernel reads both full arrays through these bounds.
+    in_start = np.searchsorted(time_array, starts, side="left")
+    in_stop = np.searchsorted(time_array, ends, side="right")
+    tg_start = np.searchsorted(time_target_array, starts, side="left")
+    tg_stop = np.searchsorted(time_target_array, ends, side="right")
 
-    idx = jitvaluefrom(
-        new_time_array,
-        time_target_array[idx_target],
-        count,
-        count_target,
-        starts,
-        mode=mode,
+    new_time_array = _concat_ranges(time_array, in_start, in_stop, copy=False)
+
+    # index into the *full* target for each kept timestamp, -1 where unmatched
+    gather_idx = jitvaluefrom_ranges(
+        time_array, time_target_array, in_start, in_stop, tg_start, tg_stop, mode
     )
-
-    # `idx` indexes the *restricted* target and uses NaN for unmatched timestamps.
-    nan_mask = np.isnan(idx)
-    has_nan = bool(nan_mask.any())
-
-    # Composing `idx_target[idx]` gathers the values once, straight out of the full
-    # target, instead of materializing the whole restricted target only to index
-    # into it again. The composed indices are neither sorted nor unique, which
-    # h5py/zarr datasets (``lazy_loading=True``) reject, so those keep the two-step
-    # gather -- there the first, monotonic gather is what loads the data.
-    can_compose = isinstance(data_target_array, np.ndarray)
+    matched = gather_idx >= 0
+    all_matched = bool(matched.all())
 
     # keep the target dtype if it is floating or if every timestamp matched,
     # otherwise upcast to float to hold the NaNs
     use_type = data_target_array.dtype
-    if has_nan and not np.issubdtype(use_type, np.floating):
+    if not (all_matched or np.issubdtype(use_type, np.floating)):
         use_type = np.float64
 
     out_shape = (len(new_time_array), *data_target_array.shape[1:])
+    take_idx = gather_idx if all_matched else gather_idx[matched]
 
-    if has_nan:
+    if isinstance(data_target_array, np.ndarray):
+        values = None  # gathered straight out of the target below
+    else:
+        # h5py/zarr datasets (``lazy_loading=True``) only accept fancy indices that
+        # are strictly increasing, while `take_idx` is neither sorted nor unique
+        # (any target matched by several timestamps repeats). Reading the distinct
+        # targets once and expanding satisfies that, and touches strictly less of
+        # the dataset than materializing the restricted target would.
+        unique_idx, inverse = np.unique(take_idx, return_inverse=True)
+        values = (
+            data_target_array[unique_idx][inverse]
+            if len(unique_idx)
+            else np.empty((0,) + data_target_array.shape[1:], dtype=use_type)
+        )
+
+    if all_matched:
+        new_data_array = np.empty(out_shape, dtype=use_type)
+        if values is None:
+            np.take(data_target_array, take_idx, axis=0, out=new_data_array)
+        else:
+            new_data_array[:] = values
+    else:
         # `use_type` is necessarily floating here
         new_data_array = np.full(out_shape, np.nan, dtype=use_type)
-        valid = ~nan_mask
-        local = idx[valid].astype(np.int64)
-        if can_compose:
-            new_data_array[valid] = data_target_array[idx_target[local]]
-        else:
-            new_data_array[valid] = data_target_array[idx_target][local]
-    else:
-        local = idx.astype(np.int64)
-        if can_compose:
-            new_data_array = np.empty(out_shape, dtype=use_type)
-            np.take(data_target_array, idx_target[local], axis=0, out=new_data_array)
-        else:
-            new_data_array = data_target_array[idx_target][local]
+        new_data_array[matched] = (
+            data_target_array[take_idx] if values is None else values
+        )
 
     return new_time_array, new_data_array
 

--- a/pynapple/core/_jitted_functions.py
+++ b/pynapple/core/_jitted_functions.py
@@ -104,6 +104,12 @@ def jitrestrict_with_count(time_array, starts, ends, dtype=np.int64):
 # is much worse than either, at 1.27x average and 3.6x worst case.
 VALUE_FROM_BSEARCH_RATIO = 128
 
+# The helpers below are called once per timestamp from the innermost loops, so they
+# are declared inline="always". That makes numba paste their body into the caller
+# instead of emitting a call. Consequences are that: there is no longer a
+# function call per element, and because `mode` is the same on every iteration,
+# the compiler can test it once before the loop rather than on every timestamp.
+
 
 @jit(nopython=True, cache=True, inline="always")
 def use_bsearch_match(n_in, n_tg):

--- a/pynapple/core/_jitted_functions.py
+++ b/pynapple/core/_jitted_functions.py
@@ -91,105 +91,239 @@ def jitrestrict_with_count(time_array, starts, ends, dtype=np.int64):
     return ix[0:x], count
 
 
-@jit(nopython=True, cache=True)
-def jitvaluefrom(
-    time_array,
-    time_target_array,
-    count,
-    count_target,
-    starts,
-    mode,
-):
+# Within one epoch, matching `n` timestamps against `d` targets costs ~n*log2(d)
+# cache-missing jumps by binary search, versus ~n+d sequential steps by merge scan,
+# so binary search only pays when the input is far sparser than the target.
+#
+# The measured crossover is not a fixed ratio: it is d/n ~ 64 at d=1e4 and doubles
+# per decade (128, 256, 512 at 1e5, 1e6, 1e7), because a probe gets more expensive
+# as the target outgrows each cache level. A constant is used anyway -- it costs at
+# most 1.23x versus always picking the better kernel, and 1.7% on average over that
+# grid, whereas fitting the growth (4*d**0.3 tracks it almost exactly) would bake
+# one machine's cache hierarchy into the source. The textbook n*log2(d) < n+d test
+# is much worse than either, at 1.27x average and 3.6x worst case.
+VALUE_FROM_BSEARCH_RATIO = 128
+
+
+@jit(nopython=True, cache=True, inline="always")
+def _vf_first_of_run(time_target_array, index, start):
+    """First index of the run of targets sharing ``time_target_array[index]``.
+
+    pynapple accepts duplicate timestamps: they are neither rejected nor
+    deduplicated on construction, and a unit conversion can create them (e.g.
+    ``Ts(t=[1000.0, 1000.0], time_units="ms")``). So a run of identical target
+    timestamps is reachable, and which member of it a mode resolves to is
+    user-visible behaviour that must be preserved.
+
+    Parameters
+    ----------
+    time_target_array : ndarray
+        Full, sorted target time array.
+    index : int
+        Index somewhere inside the run.
+    start : int
+        First index of the epoch's target slice; the walk stops there.
+
+    Returns
+    -------
+    int
+        Lowest index ``>= start`` holding the same timestamp as ``index``.
     """
-    Compute value_from in a loop.
+    while index > start and time_target_array[index - 1] == time_target_array[index]:
+        index -= 1
+    return index
+
+
+@jit(nopython=True, cache=True, inline="always")
+def _vf_last_of_run(time_target_array, index, stop):
+    """Last index of the run of targets sharing ``time_target_array[index]``.
+
+    See :func:`_vf_first_of_run` on why runs of equal timestamps are reachable.
+
+    Parameters
+    ----------
+    time_target_array : ndarray
+        Full, sorted target time array.
+    index : int
+        Index somewhere inside the run.
+    stop : int
+        One past the last index of the epoch's target slice; the walk stops there.
+
+    Returns
+    -------
+    int
+        Highest index ``< stop`` holding the same timestamp as ``index``.
+    """
+    while index + 1 < stop and time_target_array[index + 1] == time_target_array[index]:
+        index += 1
+    return index
+
+
+@jit(nopython=True, cache=True, inline="always")
+def _vf_match(time_target_array, timestamp, first_after, start, stop, mode):
+    """Pick the target matching one timestamp, within one epoch's target slice.
+
+    All three modes are derived from a single pivot, so the caller only has to
+    locate that pivot once (by binary search or by a merge scan, whichever is
+    cheaper) and this decides what it means.
+
+    Parameters
+    ----------
+    time_target_array : ndarray
+        Full, sorted target time array.
+    timestamp : float
+        The input timestamp to match.
+    first_after : int
+        Index of the first target in ``[start, stop)`` strictly greater than
+        ``timestamp`` (``stop`` if there is none). Its predecessor is therefore the
+        last target less than or equal to ``timestamp``.
+    start, stop : int
+        Half-open bounds of this epoch's slice of ``time_target_array``.
+    mode : int
+        0 before, 1 closest, 2 after.
+
+    Returns
+    -------
+    int
+        Index into ``time_target_array``, or -1 when no target qualifies.
+
+    Notes
+    -----
+    Tie-breaking reproduces the pre-rewrite kernel exactly, including two rules that
+    are inconsistent with each other but are existing, user-visible behaviour:
+
+    - on a run of identical target timestamps, ``before`` and ``after`` resolve to
+      the *first* of the run while ``closest`` resolves to the *last*;
+    - when the two neighbours are exactly equidistant, ``closest`` resolves to the
+      *later* one.
+    """
+    last_at_or_before = first_after - 1
+
+    if mode == 0:  # before: last target <= timestamp
+        if (
+            last_at_or_before >= start
+            and time_target_array[last_at_or_before] == timestamp
+        ):
+            return _vf_first_of_run(time_target_array, last_at_or_before, start)
+        return last_at_or_before if last_at_or_before >= start else -1
+
+    if mode == 2:  # after: first target >= timestamp
+        if (
+            last_at_or_before >= start
+            and time_target_array[last_at_or_before] == timestamp
+        ):
+            return _vf_first_of_run(time_target_array, last_at_or_before, start)
+        return first_after if first_after < stop else -1
+
+    # closest: whichever neighbour is nearer
+    if last_at_or_before < start:  # nothing at or below: only the upper neighbour
+        if first_after >= stop:
+            return -1
+        return _vf_last_of_run(time_target_array, first_after, stop)
+    if first_after >= stop:  # nothing above: only the lower neighbour
+        return last_at_or_before
+
+    upper = _vf_last_of_run(time_target_array, first_after, stop)
+    # `<=`, not `<`: on an exact distance tie the reference kernel keeps walking
+    # forward (its break test is `new_interval > interval`), landing on the later
+    # target. A strict `<` here silently disagrees on every equidistant match.
+    if (time_target_array[upper] - timestamp) <= (
+        timestamp - time_target_array[last_at_or_before]
+    ):
+        return upper
+    return last_at_or_before
+
+
+@jit(nopython=True, cache=True)
+def jitvaluefrom_ranges(
+    time_array, time_target_array, starts_in, ends_in, starts_tg, ends_tg, mode
+):
+    """Compute value_from indices from per-epoch slice boundaries.
+
+    Unlike the pre-rewrite kernel, this takes the *full* time arrays plus the
+    half-open slice boundaries of each epoch, so neither array has to be restricted
+    and gathered beforehand, and per-epoch offsets are accumulated rather than
+    recomputed with an O(n_epochs^2) prefix sum.
 
     Parameters
     ----------
     time_array : ndarray
-        The time array for the input.
+        Full, sorted input time array.
     time_target_array : ndarray
-        The time array for the target.
-    count : ndarray[int]
-        Count how many input time points are in each epoch. len(count) is the number of epochs.
-    count_target  ndarray[int]
-        Count how many target time points are in each epoch. len(count_target) is the number of epochs.
-    starts : ndarray[int]
-        Start time for each epoch.
+        Full, sorted target time array.
+    starts_in, ends_in : ndarray[int64]
+        Half-open [start, end) boundaries of each epoch within ``time_array``.
+    starts_tg, ends_tg : ndarray[int64]
+        Half-open [start, end) boundaries of each epoch within
+        ``time_target_array``.
     mode : int
         0 before, 1 closest, 2 after.
+
+    Returns
+    -------
+    ndarray[int64]
+        For each in-epoch input timestamp, the index into ``time_target_array`` of
+        the matching target, or -1 when none qualifies. Length is the total number
+        of in-epoch input timestamps, epochs concatenated in order.
     """
-    # Get the number of intervals, the length of time_array, and the length of time_target_array
-    m = starts.shape[0]
-    n = time_array.shape[0]
-    d = time_target_array.shape[0]
+    n_epochs = starts_in.shape[0]
 
-    # Initialize an array to store indices with NaN as default values
-    idx = np.full(n, np.nan)
+    n_out = 0
+    for k in range(n_epochs):
+        n_out += ends_in[k] - starts_in[k]
 
-    # Proceed only if both time arrays have elements
-    if n > 0 and d > 0:
-        for k in range(m):  # Iterate through each epoch
-            # Check if there are time stamps in both arrays
-            if count[k] > 0 and count_target[k] > 0:
-                t = np.sum(count[0:k])
-                i = np.sum(count_target[0:k])
-                maxt = (
-                    t + count[k]
-                )  # Maximum index for time_array in the current interval
-                maxi = i + count_target[k]  # Maximum index in the target array
-                while t < maxt:  # Iterate over the current interval in time_array
-                    # compute signed or abs temporal difference
-                    # abs for closest, signed for after or before
-                    if mode != 1:
-                        interval = time_target_array[i] - time_array[t]
+    idx = np.full(n_out, -1, dtype=np.int64)
+
+    out_offset = 0
+    for k in range(n_epochs):
+        in_start = starts_in[k]
+        n_in = ends_in[k] - in_start
+        tg_start = starts_tg[k]
+        tg_stop = ends_tg[k]
+        n_tg = tg_stop - tg_start
+        if n_tg == 0:  # no target in this epoch: every timestamp stays unmatched
+            out_offset += n_in
+            continue
+
+        if n_in * VALUE_FROM_BSEARCH_RATIO < n_tg:
+            # input far sparser than the target: binary search each timestamp.
+            # The search spans the whole epoch every time on purpose -- narrowing
+            # the lower bound from the previous result measures ~2.8x slower, as
+            # it breaks the otherwise predictable access pattern.
+            for i in range(n_in):
+                timestamp = time_array[in_start + i]
+                left = tg_start
+                right = tg_stop
+                while left < right:  # upper bound: first target > timestamp
+                    # equivalent to floor(left + right / 2)
+                    # shifting binary numbers by one position gives
+                    # the half (10 in binary is 1010 shifted is 0101, which is 5)
+                    mid = (left + right) >> 1
+                    if time_target_array[mid] <= timestamp:
+                        left = mid + 1
                     else:
-                        interval = abs(time_target_array[i] - time_array[t])
+                        right = mid
+                idx[out_offset + i] = _vf_match(
+                    time_target_array, timestamp, left, tg_start, tg_stop, mode
+                )
+        else:
+            # comparable sizes: one sequential merge pass. `first_after` never
+            # rewinds, because the input timestamps are non-decreasing, so the whole
+            # epoch costs n_in + n_tg steps rather than n_in binary searches.
+            first_after = tg_start
+            for i in range(n_in):
+                timestamp = time_array[in_start + i]
+                while (
+                    first_after < tg_stop
+                    and time_target_array[first_after] <= timestamp
+                ):
+                    first_after += 1
+                idx[out_offset + i] = _vf_match(
+                    time_target_array, timestamp, first_after, tg_start, tg_stop, mode
+                )
+        out_offset += n_in
 
-                    idx[t] = float(i)  # Store the initial index
-
-                    i += 1
-                    while (
-                        i < maxi
-                    ):  # Iterate through time_target_array within the current interval
-                        # check the next temporal difference
-                        if mode != 1:
-                            new_interval = time_target_array[i] - time_array[t]
-                            break_cond = (
-                                ((new_interval > 0) and (interval <= 0))
-                                or (interval >= 0)
-                                if mode == 0
-                                else ((new_interval < 0) and (interval >= 0))
-                                or (interval >= 0)
-                            )
-                            nan_cond = interval > 0 if mode == 0 else new_interval < 0
-                        else:
-                            new_interval = abs(time_target_array[i] - time_array[t])
-                            break_cond = new_interval > interval
-                            nan_cond = False
-
-                        if break_cond:  # Break if the new interval is larger
-                            if nan_cond:
-                                idx[t] = np.nan
-                            break
-                        else:
-                            idx[t] = float(i)  # Update the index with the closer target
-                            interval = new_interval  # Update the interval
-                            i += 1
-
-                    if i == maxi:
-                        if mode == 2:
-                            new_interval = time_target_array[i - 1] - time_array[t]
-                            nan_cond = new_interval < 0
-                        elif mode == 0:
-                            nan_cond = interval > 0
-                        else:
-                            nan_cond = False
-                        if nan_cond:
-                            idx[t] = np.nan
-                    i -= 1  # Revert to the last valid index
-                    t += 1  # Move to the next time point
-
-    return idx  # Return the array of indices
+    return idx
 
 
 @jit(nopython=True, cache=True)

--- a/pynapple/core/_jitted_functions.py
+++ b/pynapple/core/_jitted_functions.py
@@ -106,6 +106,29 @@ VALUE_FROM_BSEARCH_RATIO = 128
 
 
 @jit(nopython=True, cache=True, inline="always")
+def use_bsearch_match(n_in, n_tg):
+    """Whether to match this epoch by binary search rather than a merge scan.
+
+    Exposed (and jitted so the kernel can call it) so the threshold can be tested
+    directly: the branch itself is inside compiled code and cannot be spied on, and
+    picking the wrong one costs speed without changing any result.
+
+    Parameters
+    ----------
+    n_in : int
+        Input timestamps in the epoch.
+    n_tg : int
+        Targets in the epoch.
+
+    Returns
+    -------
+    bool
+        True to binary search, False to merge scan.
+    """
+    return n_in * VALUE_FROM_BSEARCH_RATIO < n_tg
+
+
+@jit(nopython=True, cache=True, inline="always")
 def _vf_first_of_run(time_target_array, index, start):
     """First index of the run of targets sharing ``time_target_array[index]``.
 
@@ -285,7 +308,7 @@ def jitvaluefrom_ranges(
             out_offset += n_in
             continue
 
-        if n_in * VALUE_FROM_BSEARCH_RATIO < n_tg:
+        if use_bsearch_match(n_in, n_tg):
             # input far sparser than the target: binary search each timestamp.
             # The search spans the whole epoch every time on purpose -- narrowing
             # the lower bound from the previous result measures ~2.8x slower, as

--- a/tests/test_jitted.py
+++ b/tests/test_jitted.py
@@ -668,7 +668,9 @@ def test_jitvaluefrom_single_target_mode_before():
     # a single target in the epoch used to trigger an undefined nan_cond at mode=0
     time_array = np.array([1.0, 2.0])
     time_target = np.array([1.5])
-    idx = _valuefrom_ranges(time_array, time_target, np.array([0.0]), np.array([3.0]), 0)
+    idx = _valuefrom_ranges(
+        time_array, time_target, np.array([0.0]), np.array([3.0]), 0
+    )
     assert idx[0] == -1  # target 1.5 is after timestamp 1.0 → no before-target
     assert idx[1] == 0  # target 1.5 is before timestamp 2.0 → target index 0
 
@@ -677,6 +679,8 @@ def test_jitvaluefrom_single_target_mode_after():
     # single target in the epoch, mode=2 (regression guard)
     time_array = np.array([1.0, 2.0])
     time_target = np.array([1.5])
-    idx = _valuefrom_ranges(time_array, time_target, np.array([0.0]), np.array([3.0]), 2)
+    idx = _valuefrom_ranges(
+        time_array, time_target, np.array([0.0]), np.array([3.0]), 2
+    )
     assert idx[0] == 0  # target 1.5 is after timestamp 1.0 → target index 0
     assert idx[1] == -1  # target 1.5 is before timestamp 2.0 → no after-target

--- a/tests/test_jitted.py
+++ b/tests/test_jitted.py
@@ -652,29 +652,31 @@ def test_jitunion_isets_empty():
     assert len(e) == 0
 
 
+def _valuefrom_ranges(time_array, time_target, starts, ends, mode):
+    return nap.core._jitted_functions.jitvaluefrom_ranges(
+        time_array,
+        time_target,
+        np.searchsorted(time_array, starts, side="left"),
+        np.searchsorted(time_array, ends, side="right"),
+        np.searchsorted(time_target, starts, side="left"),
+        np.searchsorted(time_target, ends, side="right"),
+        mode,
+    )
+
+
 def test_jitvaluefrom_single_target_mode_before():
-    # count_target[k]==1 triggers undefined nan_cond when mode=0
+    # a single target in the epoch used to trigger an undefined nan_cond at mode=0
     time_array = np.array([1.0, 2.0])
     time_target = np.array([1.5])
-    count = np.array([2], dtype=np.int64)
-    count_target = np.array([1], dtype=np.int64)
-    starts = np.array([0.0])
-    idx = nap.core._jitted_functions.jitvaluefrom(
-        time_array, time_target, count, count_target, starts, 0
-    )
-    assert np.isnan(idx[0])  # target 1.5 is after timestamp 1.0 → no before-target
-    assert idx[1] == 0.0  # target 1.5 is before timestamp 2.0 → target index 0
+    idx = _valuefrom_ranges(time_array, time_target, np.array([0.0]), np.array([3.0]), 0)
+    assert idx[0] == -1  # target 1.5 is after timestamp 1.0 → no before-target
+    assert idx[1] == 0  # target 1.5 is before timestamp 2.0 → target index 0
 
 
 def test_jitvaluefrom_single_target_mode_after():
-    # count_target[k]==1, mode=2 (already handled, regression guard)
+    # single target in the epoch, mode=2 (regression guard)
     time_array = np.array([1.0, 2.0])
     time_target = np.array([1.5])
-    count = np.array([2], dtype=np.int64)
-    count_target = np.array([1], dtype=np.int64)
-    starts = np.array([0.0])
-    idx = nap.core._jitted_functions.jitvaluefrom(
-        time_array, time_target, count, count_target, starts, 2
-    )
-    assert idx[0] == 0.0  # target 1.5 is after timestamp 1.0 → target index 0
-    assert np.isnan(idx[1])  # target 1.5 is before timestamp 2.0 → no after-target
+    idx = _valuefrom_ranges(time_array, time_target, np.array([0.0]), np.array([3.0]), 2)
+    assert idx[0] == 0  # target 1.5 is after timestamp 1.0 → target index 0
+    assert idx[1] == -1  # target 1.5 is before timestamp 2.0 → no after-target

--- a/tests/test_lazy_loading.py
+++ b/tests/test_lazy_loading.py
@@ -1,6 +1,7 @@
 import warnings
 from contextlib import nullcontext as does_not_raise
 from pathlib import Path
+from unittest.mock import patch
 
 import h5py
 import numpy as np
@@ -200,6 +201,73 @@ def test_lazy_load_hdf5_tsdframe_loc(tmp_path):
     #     # delete file
     #     if file_path.exists():
     #         file_path.unlink()
+
+
+def _lazy_and_eager_tsdframe(tmp_path):
+    """A TsdFrame backed by an h5py dataset, and its eagerly loaded twin."""
+    file_path = tmp_path / Path("data.h5")
+    data = np.arange(60, dtype=float).reshape(20, 3)
+    with h5py.File(file_path, "w") as f:
+        f.create_dataset("data", data=data)
+    h5_data = h5py.File(file_path, "r")["data"]
+    t = np.arange(20, dtype=float)
+    lazy = nap.TsdFrame(t=t, d=h5_data, load_array=False)
+    assert not isinstance(lazy.values, np.ndarray)
+    return lazy, nap.TsdFrame(t=t, d=data)
+
+
+@pytest.mark.parametrize("mode", ["closest", "before", "after"])
+@pytest.mark.parametrize(
+    "ep",
+    [
+        # every timestamp matches -> the all-valid gather
+        nap.IntervalSet(0, 19),
+        nap.IntervalSet([0, 10], [4, 19]),
+        # the target ends at t=19, so the second epoch holds input timestamps but
+        # no target at all -> unmatched (NaN) gather, for every mode
+        nap.IntervalSet([0, 21], [19, 24]),
+    ],
+)
+def test_lazy_load_hdf5_value_from(mode, ep, tmp_path):
+    """`value_from` against a lazily loaded target must match the eager result.
+
+    `_value_from` gathers the matched values by composing the restrict indices
+    with the per-timestamp match indices. Whenever the input is denser than the
+    target, several timestamps match the same sample, so the composition contains
+    repeats -- which h5py/zarr datasets reject ("Indexing elements must be in
+    increasing order"). A non-ndarray target therefore falls back to a two-step
+    gather; this pins that fallback down.
+    """
+    lazy, eager = _lazy_and_eager_tsdframe(tmp_path)
+
+    # 10x denser than the target, so the matched indices repeat
+    ts = nap.Ts(t=np.arange(0.0, 24.0, 0.1))
+
+    out_lazy = ts.value_from(lazy, ep=ep, mode=mode)
+    out_eager = ts.value_from(eager, ep=ep, mode=mode)
+
+    np.testing.assert_array_equal(out_lazy.t, out_eager.t)
+    np.testing.assert_array_equal(out_lazy.values, out_eager.values)
+
+
+def test_lazy_load_hdf5_value_from_does_not_materialize(tmp_path):
+    """The lazy target must never be handed to ``np.take``.
+
+    ``np.take`` accepts an h5py dataset, but only by converting the *whole*
+    dataset to an array first -- which silently defeats lazy loading instead of
+    raising. Only the repeat-free case would reach it, so guard it explicitly.
+    """
+    lazy, _ = _lazy_and_eager_tsdframe(tmp_path)
+    ts = nap.Ts(t=np.arange(0.0, 19.0, 0.1))
+
+    real_take = np.take
+
+    def spy(a, *args, **kwargs):
+        assert isinstance(a, np.ndarray), "np.take called on the lazy target"
+        return real_take(a, *args, **kwargs)
+
+    with patch.object(np, "take", side_effect=spy):
+        ts.value_from(lazy)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_value_from_kernel.py
+++ b/tests/test_value_from_kernel.py
@@ -1,0 +1,445 @@
+"""Tests for the ``value_from`` matching kernel.
+
+:func:`jitvaluefrom_ranges` locates, for every input timestamp, the target that
+``before`` / ``closest`` / ``after`` should pick, working from per-epoch slice
+boundaries. It picks between a binary search and a merge scan per epoch, so both
+branches are exercised here, and its tie-breaking is checked against an
+independent brute-force oracle rather than against a copy of itself.
+
+The tie-breaking rules are not arbitrary: they are the behaviour pynapple has
+always had, and they are reachable from user code because duplicate timestamps
+are accepted (never rejected nor deduplicated, and a unit conversion can create
+them). They are pinned explicitly in ``test_tie_breaking_is_pinned``.
+"""
+
+import numpy as np
+import pytest
+from numba import jit
+
+import pynapple as nap
+from pynapple.core._core_functions import _concat_ranges
+from pynapple.core._jitted_functions import (
+    VALUE_FROM_BSEARCH_RATIO,
+    jitrestrict_with_count,
+    jitvaluefrom_ranges,
+    use_bsearch_match,
+)
+
+MODES = {"before": 0, "closest": 1, "after": 2}
+
+
+# --------------------------------------------------------------------------
+# frozen pre-rewrite kernel, kept as a regression reference
+# --------------------------------------------------------------------------
+
+
+@jit(nopython=True, cache=True)
+def legacy_jitvaluefrom(
+    time_array, time_target_array, count, count_target, starts, mode
+):
+    """The ``jitvaluefrom`` that pynapple shipped before ``jitvaluefrom_ranges``.
+
+    Copied here verbatim when it was removed from the library, so the rewrite can
+    keep being checked against the behaviour that actually shipped rather than only
+    against a reimplementation of what that behaviour was believed to be. Do not
+    "fix" or tidy this: its value is that it is unchanged. It takes both arrays
+    already restricted, plus per-epoch counts.
+    """
+    m = starts.shape[0]
+    n = time_array.shape[0]
+    d = time_target_array.shape[0]
+
+    idx = np.full(n, np.nan)
+
+    if n > 0 and d > 0:
+        for k in range(m):
+            if count[k] > 0 and count_target[k] > 0:
+                t = np.sum(count[0:k])
+                i = np.sum(count_target[0:k])
+                maxt = t + count[k]
+                maxi = i + count_target[k]
+                while t < maxt:
+                    if mode != 1:
+                        interval = time_target_array[i] - time_array[t]
+                    else:
+                        interval = abs(time_target_array[i] - time_array[t])
+
+                    idx[t] = float(i)
+
+                    i += 1
+                    while i < maxi:
+                        if mode != 1:
+                            new_interval = time_target_array[i] - time_array[t]
+                            break_cond = (
+                                ((new_interval > 0) and (interval <= 0))
+                                or (interval >= 0)
+                                if mode == 0
+                                else ((new_interval < 0) and (interval >= 0))
+                                or (interval >= 0)
+                            )
+                            nan_cond = interval > 0 if mode == 0 else new_interval < 0
+                        else:
+                            new_interval = abs(time_target_array[i] - time_array[t])
+                            break_cond = new_interval > interval
+                            nan_cond = False
+
+                        if break_cond:
+                            if nan_cond:
+                                idx[t] = np.nan
+                            break
+                        else:
+                            idx[t] = float(i)
+                            interval = new_interval
+                            i += 1
+
+                    if i == maxi:
+                        if mode == 2:
+                            new_interval = time_target_array[i - 1] - time_array[t]
+                            nan_cond = new_interval < 0
+                        elif mode == 0:
+                            nan_cond = interval > 0
+                        else:
+                            nan_cond = False
+                        if nan_cond:
+                            idx[t] = np.nan
+                    i -= 1
+                    t += 1
+
+    return idx
+
+
+def run_legacy(time_array, time_target_array, starts, ends, mode):
+    """Drive the frozen kernel and translate its output to the new convention.
+
+    It returns float indices into the *restricted* target with NaN for unmatched;
+    the new kernel returns int64 indices into the *full* target with -1.
+    """
+    keep_in, count = jitrestrict_with_count(time_array, starts, ends)
+    keep_tg, count_target = jitrestrict_with_count(time_target_array, starts, ends)
+    idx = legacy_jitvaluefrom(
+        time_array[keep_in],
+        time_target_array[keep_tg],
+        count,
+        count_target,
+        starts,
+        MODES[mode],
+    )
+    out = np.full(len(idx), -1, dtype=np.int64)
+    matched = ~np.isnan(idx)
+    out[matched] = keep_tg[idx[matched].astype(np.int64)]
+    return out
+
+
+# --------------------------------------------------------------------------
+# brute-force oracle
+# --------------------------------------------------------------------------
+
+
+def oracle(time_array, time_target_array, starts, ends, mode):
+    """O(n*d) reference for the kernel, written independently of it.
+
+    Returns, per kept timestamp, the index into the full target array, or -1 when
+    no target qualifies. Epochs are concatenated in order, matching the kernel.
+    """
+    out = []
+    for start, end in zip(starts, ends):
+        in_epoch = time_array[(time_array >= start) & (time_array <= end)]
+        targets = np.flatnonzero(
+            (time_target_array >= start) & (time_target_array <= end)
+        )
+        for timestamp in in_epoch:
+            if len(targets) == 0:
+                out.append(-1)
+                continue
+            candidates = time_target_array[targets]
+            if mode == "before":
+                ok = np.flatnonzero(candidates <= timestamp)
+                if not len(ok):
+                    out.append(-1)
+                elif candidates[ok[-1]] == timestamp:
+                    # an exact hit resolves to the first of the equal run
+                    out.append(targets[np.flatnonzero(candidates == timestamp)[0]])
+                else:
+                    out.append(targets[ok[-1]])
+            elif mode == "after":
+                ok = np.flatnonzero(candidates >= timestamp)
+                out.append(targets[ok[0]] if len(ok) else -1)
+            else:
+                # closest: the LAST index achieving the minimum distance. That one
+                # rule covers both a run of identical targets and two distinct
+                # targets that happen to be equidistant.
+                dist = np.abs(candidates - timestamp)
+                out.append(targets[np.flatnonzero(dist == dist.min())[-1]])
+    return np.array(out, dtype=np.int64)
+
+
+def run_kernel(time_array, time_target_array, starts, ends, mode):
+    """Drive the kernel the way ``_value_from`` does."""
+    return jitvaluefrom_ranges(
+        time_array,
+        time_target_array,
+        np.searchsorted(time_array, starts, side="left"),
+        np.searchsorted(time_array, ends, side="right"),
+        np.searchsorted(time_target_array, starts, side="left"),
+        np.searchsorted(time_target_array, ends, side="right"),
+        MODES[mode],
+    )
+
+
+# --------------------------------------------------------------------------
+# tie-breaking, pinned explicitly
+# --------------------------------------------------------------------------
+
+
+def test_tie_breaking_is_pinned():
+    """Duplicate targets and equidistant neighbours resolve as they always have.
+
+    ``before`` and ``after`` land on the *first* member of a run of identical
+    target timestamps, while ``closest`` lands on the *last*. That is inconsistent
+    but long-standing and user-visible, so it is behaviour, not an implementation
+    detail.
+    """
+    time_array = np.array([1.0, 2.0, 3.0])
+    time_target_array = np.array([1.0, 2.0, 2.0, 4.0])
+    starts, ends = np.array([0.0]), np.array([5.0])
+
+    expected = {
+        # t=2.0 hits the duplicate run at indices 1,2 -> first of the run
+        "before": [0, 1, 2],
+        "after": [0, 1, 3],
+        # t=2.0 -> last of the run; t=3.0 is equidistant from 2.0 and 4.0 -> later
+        "closest": [0, 2, 3],
+    }
+    for mode, want in expected.items():
+        got = run_kernel(time_array, time_target_array, starts, ends, mode)
+        np.testing.assert_array_equal(got, want, err_msg=f"mode={mode}")
+
+
+def test_equidistant_tie_resolves_to_the_later_target():
+    """A strict `<` in the distance comparison would silently flip these."""
+    time_array = np.array([4.0])
+    time_target_array = np.array([0.0, 3.0, 5.0])  # |4-3| == |5-4|
+    got = run_kernel(time_array, time_target_array, np.array([0.0]), np.array([9.0]), "closest")
+    np.testing.assert_array_equal(got, [2])
+
+
+def test_tie_breaking_is_visible_through_the_public_api():
+    """The kernel's tie rules are reachable without touching internals."""
+    target = nap.Tsd(t=np.array([1.0, 2.0, 2.0, 4.0]), d=np.array([10.0, 20.0, 21.0, 40.0]))
+    ts = nap.Ts(t=np.array([2.0]))
+    assert ts.value_from(target, mode="before").values[0] == 20.0
+    assert ts.value_from(target, mode="after").values[0] == 20.0
+    assert ts.value_from(target, mode="closest").values[0] == 21.0
+
+
+# --------------------------------------------------------------------------
+# differential against the oracle
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", list(MODES))
+@pytest.mark.parametrize(
+    "kind", ["uniform", "exact_hits", "duplicate_runs", "integer_grid"]
+)
+def test_matches_oracle_and_legacy_kernel(mode, kind):
+    """Randomised differential test across the input shapes that matter.
+
+    Checked against both references: the brute-force oracle (independent of how the
+    kernel works) and the frozen pre-rewrite kernel (independent of what anyone
+    believes the rules are). Agreeing with only one of them is not enough.
+
+    ``integer_grid`` is not redundant with ``uniform``: exact distance ties between
+    two distinct targets essentially never occur with random floats, so a bug in
+    the equidistant rule is invisible without it.
+    """
+    rng = np.random.default_rng(abs(hash((mode, kind))) % (2**32))
+    horizon = 10.0
+    for _ in range(400):
+        n = int(rng.integers(0, 25))
+        d = int(rng.integers(0, 25))
+        time_array = np.sort(rng.uniform(0, horizon, n))
+        time_target_array = np.sort(rng.uniform(0, horizon, d))
+        if kind == "exact_hits" and n and d:
+            time_target_array = np.sort(
+                np.concatenate([time_target_array, rng.choice(time_array, min(n, 4))])
+            )
+        elif kind == "duplicate_runs" and d:
+            time_target_array = np.sort(
+                np.repeat(time_target_array[: max(1, d // 3)], 4)
+            )
+        elif kind == "integer_grid":
+            time_array = np.sort(rng.integers(0, 8, n).astype(float))
+            time_target_array = np.sort(rng.integers(0, 8, max(d, 1)).astype(float))
+
+        n_epochs = int(rng.integers(1, 4))
+        edges = np.sort(rng.uniform(-1, horizon + 1, 2 * n_epochs))
+        starts, ends = edges[0::2].copy(), edges[1::2].copy()
+        keep = starts < ends
+        if not keep.any():
+            continue
+        starts, ends = starts[keep], ends[keep]
+
+        got = run_kernel(time_array, time_target_array, starts, ends, mode)
+        context = (
+            f"t={time_array!r} tt={time_target_array!r} "
+            f"starts={starts!r} ends={ends!r} mode={mode}"
+        )
+        np.testing.assert_array_equal(
+            got,
+            oracle(time_array, time_target_array, starts, ends, mode),
+            err_msg=f"disagrees with the oracle: {context}",
+        )
+        np.testing.assert_array_equal(
+            got,
+            run_legacy(time_array, time_target_array, starts, ends, mode),
+            err_msg=f"disagrees with the pre-rewrite kernel: {context}",
+        )
+
+
+# --------------------------------------------------------------------------
+# both dispatch branches
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "n_in, n_tg, expected_branch",
+    [
+        (1, VALUE_FROM_BSEARCH_RATIO, "merge"),  # exactly at the threshold
+        (1, VALUE_FROM_BSEARCH_RATIO + 1, "bsearch"),  # one past it
+        (1, VALUE_FROM_BSEARCH_RATIO - 1, "merge"),
+        (0, 1000, "bsearch"),  # degenerate, must not divide by anything
+        (1000, 0, "merge"),
+        (1000, 1000, "merge"),
+    ],
+)
+def test_bsearch_threshold(n_in, n_tg, expected_branch):
+    """Pin the dispatch predicate itself.
+
+    Nothing else can: both branches return identical results by construction, so a
+    flipped predicate is invisible to every correctness test in this file.
+    """
+    assert use_bsearch_match(n_in, n_tg) == (expected_branch == "bsearch")
+
+
+@pytest.mark.parametrize("mode", list(MODES))
+@pytest.mark.parametrize(
+    "n_in, n_tg, expected_branch",
+    [
+        (1, 4 * VALUE_FROM_BSEARCH_RATIO, "bsearch"),
+        (4, 8 * VALUE_FROM_BSEARCH_RATIO, "bsearch"),
+        (200, 200, "merge"),
+        (VALUE_FROM_BSEARCH_RATIO, VALUE_FROM_BSEARCH_RATIO, "merge"),
+    ],
+)
+def test_both_dispatch_branches_agree_with_oracle(mode, n_in, n_tg, expected_branch):
+    """The per-epoch switch must not change results, only speed.
+
+    The branch taken inside the compiled kernel cannot be observed, so the sizes are
+    chosen to sit unambiguously on each side of the threshold, confirmed here
+    against the same predicate the kernel calls.
+    """
+    assert use_bsearch_match(n_in, n_tg) == (expected_branch == "bsearch")
+
+    rng = np.random.default_rng(0)
+    horizon = 100.0
+    time_array = np.sort(rng.uniform(0, horizon, n_in))
+    time_target_array = np.sort(rng.uniform(0, horizon, n_tg))
+    starts, ends = np.array([0.0]), np.array([horizon])
+
+    np.testing.assert_array_equal(
+        run_kernel(time_array, time_target_array, starts, ends, mode),
+        oracle(time_array, time_target_array, starts, ends, mode),
+    )
+
+
+@pytest.mark.parametrize("mode", list(MODES))
+def test_mixed_density_epochs(mode):
+    """One IntervalSet where the switch resolves differently per epoch."""
+    rng = np.random.default_rng(3)
+    # epoch 0: sparse input over a dense target -> binary search
+    # epoch 1: comparable sizes -> merge scan
+    sparse_in = np.sort(rng.uniform(0, 10, 2))
+    dense_in = np.sort(rng.uniform(20, 30, 300))
+    time_array = np.concatenate([sparse_in, dense_in])
+    time_target_array = np.concatenate(
+        [np.sort(rng.uniform(0, 10, 4 * VALUE_FROM_BSEARCH_RATIO)),
+         np.sort(rng.uniform(20, 30, 300))]
+    )
+    starts, ends = np.array([0.0, 20.0]), np.array([10.0, 30.0])
+
+    np.testing.assert_array_equal(
+        run_kernel(time_array, time_target_array, starts, ends, mode),
+        oracle(time_array, time_target_array, starts, ends, mode),
+    )
+
+
+# --------------------------------------------------------------------------
+# degenerate inputs
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", list(MODES))
+@pytest.mark.parametrize(
+    "time_array, time_target_array",
+    [
+        (np.array([]), np.array([1.0, 2.0])),  # no input
+        (np.array([1.0, 2.0]), np.array([])),  # no target
+        (np.array([]), np.array([])),  # neither
+        (np.array([1.0]), np.array([1.0])),  # exactly one of each, coincident
+    ],
+)
+def test_degenerate_inputs(mode, time_array, time_target_array):
+    starts, ends = np.array([0.0]), np.array([5.0])
+    got = run_kernel(time_array, time_target_array, starts, ends, mode)
+    assert len(got) == len(time_array)
+    np.testing.assert_array_equal(
+        got, oracle(time_array, time_target_array, starts, ends, mode)
+    )
+
+
+@pytest.mark.parametrize("mode", list(MODES))
+def test_epoch_with_input_but_no_target(mode):
+    """Every timestamp in such an epoch is unmatched, whatever the mode."""
+    time_array = np.array([1.0, 2.0, 11.0, 12.0])
+    # brackets every timestamp of the first epoch on both sides, so a match exists
+    # there for all three modes; nothing at all lands in [10, 13]
+    time_target_array = np.array([0.5, 2.5])
+    got = run_kernel(
+        time_array, time_target_array, np.array([0.0, 10.0]), np.array([3.0, 13.0]), mode
+    )
+    assert (got[2:] == -1).all(), "epoch without any target must be all unmatched"
+    assert (got[:2] >= 0).all(), "epoch with bracketing targets must all match"
+
+
+# --------------------------------------------------------------------------
+# _concat_ranges
+# --------------------------------------------------------------------------
+
+
+def test_concat_ranges_returns_a_view_only_when_contiguous_and_allowed():
+    array = np.arange(20.0)
+    contiguous = (np.array([2, 7]), np.array([7, 12]))  # ranges tile [2, 12)
+    gapped = (np.array([2, 8]), np.array([5, 12]))  # a gap at [5, 8)
+
+    view = _concat_ranges(array, *contiguous, copy=False)
+    assert np.shares_memory(view, array)
+    np.testing.assert_array_equal(view, array[2:12])
+
+    assert not np.shares_memory(_concat_ranges(array, *contiguous, copy=True), array)
+    assert not np.shares_memory(_concat_ranges(array, *gapped, copy=False), array)
+    np.testing.assert_array_equal(
+        _concat_ranges(array, *gapped, copy=False),
+        np.concatenate([array[2:5], array[8:12]]),
+    )
+
+
+def test_concat_ranges_keeps_trailing_dimensions():
+    array = np.arange(30.0).reshape(10, 3)
+    out = _concat_ranges(array, np.array([1, 6]), np.array([3, 8]), copy=True)
+    np.testing.assert_array_equal(out, np.concatenate([array[1:3], array[6:8]]))
+
+
+def test_concat_ranges_empty_selection():
+    array = np.arange(10.0)
+    out = _concat_ranges(array, np.array([4]), np.array([4]), copy=False)
+    assert out.shape == (0,)

--- a/tests/test_value_from_kernel.py
+++ b/tests/test_value_from_kernel.py
@@ -219,13 +219,17 @@ def test_equidistant_tie_resolves_to_the_later_target():
     """A strict `<` in the distance comparison would silently flip these."""
     time_array = np.array([4.0])
     time_target_array = np.array([0.0, 3.0, 5.0])  # |4-3| == |5-4|
-    got = run_kernel(time_array, time_target_array, np.array([0.0]), np.array([9.0]), "closest")
+    got = run_kernel(
+        time_array, time_target_array, np.array([0.0]), np.array([9.0]), "closest"
+    )
     np.testing.assert_array_equal(got, [2])
 
 
 def test_tie_breaking_is_visible_through_the_public_api():
     """The kernel's tie rules are reachable without touching internals."""
-    target = nap.Tsd(t=np.array([1.0, 2.0, 2.0, 4.0]), d=np.array([10.0, 20.0, 21.0, 40.0]))
+    target = nap.Tsd(
+        t=np.array([1.0, 2.0, 2.0, 4.0]), d=np.array([10.0, 20.0, 21.0, 40.0])
+    )
     ts = nap.Ts(t=np.array([2.0]))
     assert ts.value_from(target, mode="before").values[0] == 20.0
     assert ts.value_from(target, mode="after").values[0] == 20.0
@@ -362,8 +366,10 @@ def test_mixed_density_epochs(mode):
     dense_in = np.sort(rng.uniform(20, 30, 300))
     time_array = np.concatenate([sparse_in, dense_in])
     time_target_array = np.concatenate(
-        [np.sort(rng.uniform(0, 10, 4 * VALUE_FROM_BSEARCH_RATIO)),
-         np.sort(rng.uniform(20, 30, 300))]
+        [
+            np.sort(rng.uniform(0, 10, 4 * VALUE_FROM_BSEARCH_RATIO)),
+            np.sort(rng.uniform(20, 30, 300)),
+        ]
     )
     starts, ends = np.array([0.0, 20.0]), np.array([10.0, 30.0])
 
@@ -405,7 +411,11 @@ def test_epoch_with_input_but_no_target(mode):
     # there for all three modes; nothing at all lands in [10, 13]
     time_target_array = np.array([0.5, 2.5])
     got = run_kernel(
-        time_array, time_target_array, np.array([0.0, 10.0]), np.array([3.0, 13.0]), mode
+        time_array,
+        time_target_array,
+        np.array([0.0, 10.0]),
+        np.array([3.0, 13.0]),
+        mode,
     )
     assert (got[2:] == -1).all(), "epoch without any target must be all unmatched"
     assert (got[:2] >= 0).all(), "epoch with bracketing targets must all match"


### PR DESCRIPTION
## Summary

`value_from` was doing a large amount of work it then threw away: it restricted both time arrays with a full O(n) scan, materialised the entire restricted target, and indexed into it a second time. The cost therefore scaled with the length of the *target*, not with the number of timestamps actually being matched — which is why calling it once per unit (tuning curves, `TsGroup.value_from`) came out as O(units × feature length). 

This rewrites the matching kernel and its setup. Results are unchanged, bit for bit. `compute_tuning_curves` gets 2–7.5× without `tuning_curves.py` being touched at all.

Note that tuning curve computation can still be sped up in a subsequent PR.

## Optimizations

- **Per-epoch boundaries instead of restrict + gather.** Four `searchsorted` calls replace two O(n) merge scans and every fancy-index gather. The kernel reads both full arrays through `[start, stop)` bounds, so nothing is restricted or copied up front. (0.002 ms vs 1.9 ms for one epoch over 1e6 samples.)
- **Binary search vs linear scan, switched per epoch.** Matching `n` timestamps against `d` targets costs ~`n·log2(d)` cache-missing probes by binary search, or ~`n+d` sequential steps by merge scan. The switch is empirical, not the textbook `n·log2(d) < n+d` test — see the calibration note below.
- **One gather instead of two.** Match indices are composed with the epoch offsets, so the values are read once directly out of the full target instead of materialising the whole restricted target and indexing that.
- **Contiguous epochs are merged into a view.** When the epochs tile a single span (a common case, including the default `ep = data.time_support`), the output timestamps are a view of the input's, not a copy. See the reviewer note.
- **Per-epoch offsets accumulated, not recomputed.** The old kernel did `np.sum(count[0:k])` inside the epoch loop, making it O(epochs²): 2.1 ms at 1 epoch but 39 ms at 20 000.
- **`int64` with a `-1` sentinel** in place of `float64` with `NaN`, removing two `isnan` passes and an `astype` per call.
- **Replaced a Python `any()` over an ndarray** with `.any()` — 6.31 ms vs 0.012 ms at 1e6. It only fired for integer-typed targets, but when it did it cost more than the rest of the call combined.
- **Lazy targets read less than before.** h5py/zarr targets can't take the composed (unsorted, repeating) indices, so they read the distinct matched targets once and expand. That touches strictly less of the dataset than materialising the restricted target did.

## Calibration of the switch

The crossover is not a fixed ratio — it doubles per decade of target size, as a probe gets more expensive once the target outgrows each cache level:

| target size `d` | 1e4 | 1e5 | 1e6 | 1e7 |
|---|---|---|---|---|
| binary search wins from `d/n` ≥ | 64 | 128 | 256 | 512 |

Scoring candidate rules as `chosen / best` over that grid:

| rule | worst | average |
|---|---|---|
| `n·128 < d` (**used**) | 1.23× | 1.017× |
| `n·256 < d` | 2.07× | 1.038× |
| `n·4·d^0.3 < d` | 1.00× | 1.000× |
| `n·log2(d) < n+d` (textbook) | 3.62× | 1.273× |

The power law fits exactly but encodes one machine's cache hierarchy, so a constant is used instead — it costs 1.23× in the worst cell and 1.7% on average, and matches the existing `_use_searchsorted_restrict` style.

## Performance

Run the benchmarking script attached to compare with previous implementation.
[benchmark_value_from.py](https://github.com/user-attachments/files/31832909/benchmark_value_from.py)


`_value_from` in isolation, 1e6-sample target:

| target | N | before | after | |
|---|---|---|---|---|
| `Tsd` | 5 000 | 4.03 ms | 0.46 ms | 8.8× |
| `Tsd` | 100 000 | 5.69 ms | 2.30 ms | 2.5× |
| `Tsd` | 1 000 000 | 19.93 ms | 15.73 ms | 1.3× |
| `TsdFrame` (10 col) | 5 000 | 10.98 ms | 0.49 ms | 22× |
| `TsdFrame` (10 col) | 100 000 | 15.79 ms | 3.95 ms | 4.0× |
| `TsdFrame` (10 col) | 1 000 000 | 44.65 ms | 19.94 ms | 2.2× |
| N=D=200k, 20 000 epochs | — | 38.99 ms | 14.36 ms | 2.7× |

End to end:

| | before | after | |
|---|---|---|---|
| `TsGroup.value_from`, 100 units × 5k, `Tsd` target | 402 ms | 58.6 ms | 6.9× |
| `TsGroup.value_from`, 100 units × 5k, `TsdFrame`(10) | 1105 ms | 82.9 ms | 13× |
| `compute_tuning_curves`, 200 units, 100k feature | 112.4 ms | 53.9 ms | 2.1× |
| `compute_tuning_curves`, 500 units, 100k feature | 275.7 ms | 128.0 ms | 2.2× |
| `compute_tuning_curves`, 200 units, 1M feature | 753.1 ms | 100.0 ms | 7.5× |

The scaling is what changed: at 200 units, going from a 100k to a 1M feature cost 6.7× before and 1.9× now.

## For reviewers: the output shares the input's time index

When the epochs tile the input's timestamps contiguously, the returned object's time index is a view of `self.index.values` rather than a copy. The **values** buffer is always freshly allocated, and the target's arrays are never sliced at all, so nothing a caller is likely to mutate is aliased.

This matches what pynapple already does — `(tsd + 1).index is tsd.index`, and `get()` shares memory too; only `restrict()` copies. Mutating a time index is already unsupported (`tsd.t = ...`, `tsd.index = ...` and `tsd.index[i] = ...` all raise, and sortedness is a package-wide invariant), so this does not open a new failure mode.

**Question:** acceptable, or should `value_from` force the copy? 

**Open question, not addressed here:** `before`/`after` taking the first of a run while `closest` takes the last is almost comes from how the original loop was implemented. This PR freezes the existing behaviour; do we want this asymmetry?